### PR TITLE
[Feature] Redis 연동 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test": "jest 'src\\/.*\\.(controller|service|repository)\\.spec\\.ts$'"
   },
   "dependencies": {
+    "@liaoliaots/nestjs-redis": "^9.0.5",
     "@nestjs/common": "^9.0.0",
     "@nestjs/config": "^2.3.1",
     "@nestjs/core": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "dayjs": "^1.11.7",
     "dotenv-cli": "^7.2.1",
     "google-auth-library": "^8.8.0",
+    "ioredis": "^5.3.2",
     "nest-winston": "^1.9.1",
     "reflect-metadata": "^0.1.13",
     "request-ip": "^3.3.0",

--- a/src/apps/server/app.module.ts
+++ b/src/apps/server/app.module.ts
@@ -12,6 +12,9 @@ import { CustomExceptionFilter } from './filters/custom-exception.filter';
 import { LogInterceptor } from './interceptors/log.interceptor';
 import { SlackModule } from 'src/modules/slack/slack.module';
 import { AuthModule } from './auth/auth.module';
+import { RedisModule } from '@liaoliaots/nestjs-redis';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { RedisConfigFactory } from '../../modules/cache/redis/redis.factory';
 
 @Module({
   imports: [
@@ -19,6 +22,11 @@ import { AuthModule } from './auth/auth.module';
     EnvModule.forRoot(),
     LogModule.forRoot(),
     SlackModule,
+    RedisModule.forRootAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useClass: RedisConfigFactory,
+    }),
 
     // Domains
     AuthModule,

--- a/src/apps/server/auth/auth.module.ts
+++ b/src/apps/server/auth/auth.module.ts
@@ -2,8 +2,10 @@ import { Module } from '@nestjs/common';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
 import { SigninGuard } from '../guards/signin.guard';
+import { RedisCacheModule } from '../../../modules/cache/redis/redis.module';
 
 @Module({
+  imports: [RedisCacheModule],
   controllers: [AuthController],
   providers: [AuthService, SigninGuard],
 })

--- a/src/modules/cache/redis/redis.factory.ts
+++ b/src/modules/cache/redis/redis.factory.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@nestjs/common';
+import {
+  RedisModuleOptions,
+  RedisOptionsFactory,
+} from '@liaoliaots/nestjs-redis';
+import { ConfigService } from '@nestjs/config';
+
+@Injectable()
+export class RedisConfigFactory implements RedisOptionsFactory {
+  constructor(private readonly configService: ConfigService) {}
+
+  createRedisOptions(): RedisModuleOptions | Promise<RedisModuleOptions> {
+    const host =
+      this.configService.get('NODE_ENV') === 'dev'
+        ? this.configService.get('REDIS_HOST_DEV')
+        : this.configService.get('REDIS_HOST_PROD');
+    const port =
+      this.configService.get('NODE_ENV') === 'dev'
+        ? +this.configService.get('REDIS_PORT_DEV')
+        : +this.configService.get('REDIS_PORT_PROD');
+
+    return {
+      config: {
+        host,
+        port,
+      },
+    };
+  }
+}

--- a/src/modules/cache/redis/redis.factory.ts
+++ b/src/modules/cache/redis/redis.factory.ts
@@ -9,7 +9,7 @@ import { ConfigService } from '@nestjs/config';
 export class RedisConfigFactory implements RedisOptionsFactory {
   constructor(private readonly configService: ConfigService) {}
 
-  createRedisOptions(): RedisModuleOptions | Promise<RedisModuleOptions> {
+  createRedisOptions(): RedisModuleOptions {
     const host =
       this.configService.get('NODE_ENV') === 'dev'
         ? this.configService.get('REDIS_HOST_DEV')

--- a/src/modules/cache/redis/redis.module.ts
+++ b/src/modules/cache/redis/redis.module.ts
@@ -5,5 +5,6 @@ import { RedisCacheService } from './redis.service';
 @Module({
   imports: [RedisModule],
   providers: [RedisCacheService],
+  exports: [RedisCacheService],
 })
 export class RedisCacheModule {}

--- a/src/modules/cache/redis/redis.module.ts
+++ b/src/modules/cache/redis/redis.module.ts
@@ -1,0 +1,9 @@
+import { RedisModule } from '@liaoliaots/nestjs-redis';
+import { Module } from '@nestjs/common';
+import { RedisCacheService } from './redis.service';
+
+@Module({
+  imports: [RedisModule],
+  providers: [RedisCacheService],
+})
+export class RedisCacheModule {}

--- a/src/modules/cache/redis/redis.service.ts
+++ b/src/modules/cache/redis/redis.service.ts
@@ -1,0 +1,30 @@
+import { InjectRedis, RedisService } from '@liaoliaots/nestjs-redis';
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Redis } from 'ioredis';
+
+@Injectable()
+export class RedisCacheService {
+  constructor(
+    @InjectRedis() private readonly redisClient: Redis,
+    private readonly redisService: RedisService,
+    private readonly configService: ConfigService,
+  ) {
+    this.redisClient = redisService.getClient();
+  }
+
+  // value 가져오기
+  async get(key: string): Promise<string> {
+    return await this.redisClient.get(key);
+  }
+
+  // key-value 저장
+  async set(key: string, value: any, expire?: number): Promise<'OK'> {
+    return await this.redisClient.set(key, value, 'EX', expire);
+  }
+
+  // key 삭제
+  async del(key: string): Promise<number> {
+    return await this.redisClient.del(key);
+  }
+}

--- a/src/modules/cache/redis/redis.service.ts
+++ b/src/modules/cache/redis/redis.service.ts
@@ -1,6 +1,5 @@
 import { InjectRedis, RedisService } from '@liaoliaots/nestjs-redis';
 import { Injectable } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
 import { Redis } from 'ioredis';
 
 @Injectable()
@@ -8,7 +7,6 @@ export class RedisCacheService {
   constructor(
     @InjectRedis() private readonly redisClient: Redis,
     private readonly redisService: RedisService,
-    private readonly configService: ConfigService,
   ) {
     this.redisClient = redisService.getClient();
   }
@@ -19,7 +17,7 @@ export class RedisCacheService {
   }
 
   // key-value 저장
-  async set(key: string, value: any, expire?: number): Promise<'OK'> {
+  async set(key: string, value: any, expire = 3600): Promise<'OK'> {
     return await this.redisClient.set(key, value, 'EX', expire);
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -427,6 +427,11 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
+"@ioredis/commands@^1.1.1":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@ioredis/commands/-/commands-1.2.0.tgz#6d61b3097470af1fdbbe622795b8921d42018e11"
+  integrity sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==
+
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"
@@ -1904,6 +1909,11 @@ clone@^1.0.2:
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==
 
+cluster-key-slot@^1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz#88ddaa46906e303b5de30d3153b7d9fe0a0c19ac"
+  integrity sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -2124,6 +2134,11 @@ delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
+
+denque@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/denque/-/denque-2.1.0.tgz#e93e1a6569fb5e66f16a3c2a2964617d349d6ab1"
+  integrity sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==
 
 depd@2.0.0:
   version "2.0.0"
@@ -3057,6 +3072,21 @@ interpret@^1.0.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
   integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
 
+ioredis@^5.3.2:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-5.3.2.tgz#9139f596f62fc9c72d873353ac5395bcf05709f7"
+  integrity sha512-1DKMMzlIHM02eBBVOFQ1+AolGjs6+xEcM4PDL7NqOS6szq7H9jSaEkIUH6/a5Hl241LzW6JLSiAbNvTQjUupUA==
+  dependencies:
+    "@ioredis/commands" "^1.1.1"
+    cluster-key-slot "^1.1.0"
+    debug "^4.3.4"
+    denque "^2.1.0"
+    lodash.defaults "^4.2.0"
+    lodash.isarguments "^3.1.0"
+    redis-errors "^1.2.0"
+    redis-parser "^3.0.0"
+    standard-as-callback "^2.1.0"
+
 ipaddr.js@1.9.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"
@@ -3714,6 +3744,16 @@ locate-path@^6.0.0:
   integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
   dependencies:
     p-locate "^5.0.0"
+
+lodash.defaults@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
+  integrity sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==
+
+lodash.isarguments@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"
+  integrity sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==
 
 lodash.memoize@4.x:
   version "4.1.2"
@@ -4411,6 +4451,18 @@ rechoir@^0.6.2:
   dependencies:
     resolve "^1.1.6"
 
+redis-errors@^1.0.0, redis-errors@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/redis-errors/-/redis-errors-1.2.0.tgz#eb62d2adb15e4eaf4610c04afe1529384250abad"
+  integrity sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==
+
+redis-parser@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/redis-parser/-/redis-parser-3.0.0.tgz#b66d828cdcafe6b4b8a428a7def4c6bcac31c8b4"
+  integrity sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==
+  dependencies:
+    redis-errors "^1.0.0"
+
 reflect-metadata@^0.1.13:
   version "0.1.13"
   resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.1.13.tgz#67ae3ca57c972a2aa1642b10fe363fe32d49dc08"
@@ -4696,6 +4748,11 @@ stack-utils@^2.0.3:
   integrity sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==
   dependencies:
     escape-string-regexp "^2.0.0"
+
+standard-as-callback@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/standard-as-callback/-/standard-as-callback-2.1.0.tgz#8953fc05359868a77b5b9739a665c5977bb7df45"
+  integrity sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==
 
 statuses@2.0.1:
   version "2.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -693,6 +693,13 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
+"@liaoliaots/nestjs-redis@^9.0.5":
+  version "9.0.5"
+  resolved "https://registry.yarnpkg.com/@liaoliaots/nestjs-redis/-/nestjs-redis-9.0.5.tgz#8e8b1326792c83599425eca123bb3a93d6cef248"
+  integrity sha512-nPcGLj0zW4mEsYtQYfWx3o7PmrMjuzFk6+t/g2IRopAeWWUZZ/5nIJ4KTKiz/3DJEUkbX8PZqB+dOhklGF0SVA==
+  dependencies:
+    tslib "2.4.1"
+
 "@lukeed/csprng@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@lukeed/csprng/-/csprng-1.1.0.tgz#1e3e4bd05c1cc7a0b2ddbd8a03f39f6e4b5e6cfe"
@@ -4981,6 +4988,11 @@ tsconfig-paths@4.2.0, tsconfig-paths@^4.1.2:
     json5 "^2.2.2"
     minimist "^1.2.6"
     strip-bom "^3.0.0"
+
+tslib@2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.1.tgz#0d0bfbaac2880b91e22df0768e55be9753a5b17e"
+  integrity sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==
 
 tslib@2.5.0, tslib@^2.1.0:
   version "2.5.0"


### PR DESCRIPTION
# Redis 연동 파일 추가

Redis를 RefreshToken 저장소로 사용할 때 필요하므로, 서버와 연결하였습니다.

modules 폴더의 cache 폴더 아래 redis 폴더로 만들었고, 해당 폴더는 레디스 서비스 로직을 담은 폴더입니다.
그리고, 해당 폴더에서 factory는 레디스 의존성 주입에 필요한 설정을 반환해주기 위해서 만든 파일이에요.

그래서 app.module.ts에 레디스 client를 연결해주고, redis.service.ts에 있는 서비스 로직을 사용하기 위해서 RedisCacheModule을 원하는 도메인 폴더에 적용해서 사용하면 됩니다!
---
# Redis 연동 확인

<img width="797" alt="image" src="https://github.com/depromeet/13th-4team-backend/assets/83271772/a48d9505-0332-4a34-9ffa-eb8f0b5f7e57">

위처럼 set 메서드로, 첫 번째 인자에 키를 넣고 두 번째 인자로는 값을 넣어서 키-값을 설정합니다.

그리고, redis cli와 동일하게 서버 소스코드에서도 get(키)로 가져옵니다.
실제로 동작함을 위의 사진에서 확인했습니다!

테스트한 코드는 굳이 올릴 필요 없을 것 같아서 안 올렸어요
---
# Redis를 쓰는 이유

Redis를 쓰는 이유는
1. RefreshToken 저장
2. 빠른 시간 복잡도

## Refresh token 저장
- 저는 보통 refresh token을 RTR(Refresh Token Rotation)이라고 해서 refresh token으로 Access token 재발급 시에 Refresh token도 함께 재발급해주도록 구현합니다.
- 해당 방법은 refresh token의 유효 주기를 짧게 가져가서 상대적으로 보안성을 높일 수 있다는 장점이 있고, 매번 refresh token을 재발급하므로 유저가 로그인 상태를 길게 가져갈 수 있습니다.
- 하지만, jwt는 expire가 되지 않는 한 유효한 토큰으로 사용되기 때문에 이를 저장소에 저장하도록 했어요. 즉, 저장소에 있는 refresh token과 같아야지만 유효한 토큰으로 간주합니다!

## 빠른 시간 복잡도
- redis는 key-value 스토어기 때문에 시간 복잡도가 O(1)입니다. 그래서 매우 빠르게 값을 가져올 수 있어요.
- 그리고, 사이즈도 작아서 서버에 무리가 가지 않는다고 하네요?? 이건 확실하게 알아본 게 아니라 조금 더 찾아보겠습니다.