### PR TITLE
[Feature] 추상 레포지터리 설정 및 응답 엔티티 추가, 테스트용 액세스 토큰 발급 api 추가, 자기소개서 조회 api 추가

### DIFF
--- a/src/apps/server/app.module.ts
+++ b/src/apps/server/app.module.ts
@@ -17,6 +17,7 @@ import { RedisModule } from '@liaoliaots/nestjs-redis';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { RedisConfigFactory } from '../../modules/cache/redis/redis.factory';
 import { ResumesModule } from './resumes/resumes.module';
+import { TestModule } from './test/test.module';
 
 @Module({
   controllers: [AppController],
@@ -34,6 +35,7 @@ import { ResumesModule } from './resumes/resumes.module';
     // Domains
     AuthModule,
     ResumesModule,
+    TestModule,
   ],
   providers: [
     {

--- a/src/apps/server/app.module.ts
+++ b/src/apps/server/app.module.ts
@@ -16,6 +16,7 @@ import { AppController } from './app.controller';
 import { RedisModule } from '@liaoliaots/nestjs-redis';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { RedisConfigFactory } from '../../modules/cache/redis/redis.factory';
+import { ResumesModule } from './resumes/resumes.module';
 
 @Module({
   controllers: [AppController],
@@ -32,6 +33,7 @@ import { RedisConfigFactory } from '../../modules/cache/redis/redis.factory';
 
     // Domains
     AuthModule,
+    ResumesModule,
   ],
   providers: [
     {

--- a/src/apps/server/auth/auth.module.ts
+++ b/src/apps/server/auth/auth.module.ts
@@ -10,6 +10,8 @@ import { JwtStrategy } from '../guards/strategies/jwt.strategy';
 import { UserInfoRepository } from '../../../modules/database/repositories/user-info.repository';
 import { JwtRefreshStrategy } from '../guards/strategies/jwt-refresh.strategy';
 import { ApiModule } from '../../../modules/api/api.module';
+import { APP_GUARD } from '@nestjs/core';
+import { JwtAuthGuard } from '../guards/jwt-auth.guard';
 
 @Module({
   imports: [
@@ -35,6 +37,12 @@ import { ApiModule } from '../../../modules/api/api.module';
     // Repositories
     UserRepository,
     UserInfoRepository,
+
+    // Guard
+    {
+      provide: APP_GUARD,
+      useClass: JwtAuthGuard,
+    },
   ],
 })
 export class AuthModule {}

--- a/src/apps/server/auth/auth.module.ts
+++ b/src/apps/server/auth/auth.module.ts
@@ -37,12 +37,6 @@ import { JwtAuthGuard } from '../guards/jwt-auth.guard';
     // Repositories
     UserRepository,
     UserInfoRepository,
-
-    // Guard
-    {
-      provide: APP_GUARD,
-      useClass: JwtAuthGuard,
-    },
   ],
 })
 export class AuthModule {}

--- a/src/apps/server/resumes/resumes.controller.ts
+++ b/src/apps/server/resumes/resumes.controller.ts
@@ -1,0 +1,24 @@
+import { Controller, Get } from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ResumesService } from './resumes.service';
+import { User } from '../decorators/request/user.decorator';
+import { UserJwtToken } from '../auth/types/jwt-tokwn.type';
+import { ResponseEntity } from '../../../libs/utils/respone.entity';
+
+@ApiTags('resumes')
+@Controller('resumes')
+export class ResumesController {
+  constructor(private readonly resumesService: ResumesService) {}
+
+  @Get()
+  @ApiOperation({
+    summary: '자기소개서를 조회',
+    description:
+      '자기소개서를 처음 조회했을 때, 자기소개서 폴더링 목록과 각 폴더링 별 문항을 모두 출력합니다.',
+  })
+  async getAllResumes(@User() user: UserJwtToken) {
+    const resumes = await this.resumesService.getAllResumes(user.userId);
+
+    return ResponseEntity.OK_WITH_DATA(resumes);
+  }
+}

--- a/src/apps/server/resumes/resumes.controller.ts
+++ b/src/apps/server/resumes/resumes.controller.ts
@@ -1,11 +1,13 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, UseGuards } from '@nestjs/common';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { ResumesService } from './resumes.service';
 import { User } from '../decorators/request/user.decorator';
 import { UserJwtToken } from '../auth/types/jwt-tokwn.type';
 import { ResponseEntity } from '../../../libs/utils/respone.entity';
+import { JwtAuthGuard } from '../guards/jwt-auth.guard';
 
 @ApiTags('resumes')
+@UseGuards(JwtAuthGuard)
 @Controller('resumes')
 export class ResumesController {
   constructor(private readonly resumesService: ResumesService) {}

--- a/src/apps/server/resumes/resumes.module.ts
+++ b/src/apps/server/resumes/resumes.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { ResumesController } from './resumes.controller';
+import { ResumesProvider } from './resumes.service.ts';
+
+@Module({
+  imports: [],
+  controllers: [ResumesController],
+  providers: [ResumesProvider],
+})
+export class ResumesModule {}

--- a/src/apps/server/resumes/resumes.module.ts
+++ b/src/apps/server/resumes/resumes.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
 import { ResumesController } from './resumes.controller';
-import { ResumesProvider } from './resumes.service.ts';
+import { ResumesService } from './resumes.service';
+import { ResumesRepository } from '../../../modules/database/repositories/resume.repository';
 
 @Module({
   imports: [],
   controllers: [ResumesController],
-  providers: [ResumesProvider],
+  providers: [ResumesService, ResumesRepository],
 })
 export class ResumesModule {}

--- a/src/apps/server/resumes/resumes.service.ts
+++ b/src/apps/server/resumes/resumes.service.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@nestjs/common';
+import { Resume } from '@prisma/client';
+import { ResumesRepository } from '../../../modules/database/repositories/resume.repository';
+
+@Injectable()
+export class ResumesService {
+  constructor(private readonly resumesRepository: ResumesRepository) {}
+
+  async getAllResumes(userId: number): Promise<Resume[]> {
+    const resumes = await this.resumesRepository.findMany({
+      where: { userId },
+    });
+
+    return resumes;
+  }
+}

--- a/src/apps/server/test/test.controller.ts
+++ b/src/apps/server/test/test.controller.ts
@@ -1,0 +1,15 @@
+import { Body, Controller, Post } from '@nestjs/common';
+import { TestService } from './test.service';
+import { ResponseEntity } from '../../../libs/utils/respone.entity';
+
+@Controller('test')
+export class TestController {
+  constructor(private readonly testService: TestService) {}
+
+  @Post('token')
+  issueTestToken(@Body() { userId }: { userId: number }) {
+    return ResponseEntity.CREATED_WITH_DATA(
+      this.testService.issueTestToken(userId),
+    );
+  }
+}

--- a/src/apps/server/test/test.module.ts
+++ b/src/apps/server/test/test.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { TestController } from './test.controller';
+import { TestService } from './test.service';
+import { JwtModule } from '@nestjs/jwt';
+
+@Module({
+  imports: [JwtModule],
+  controllers: [TestController],
+  providers: [TestService],
+})
+export class TestModule {}

--- a/src/apps/server/test/test.service.ts
+++ b/src/apps/server/test/test.service.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { ACCESS_TOKEN_EXPIRES_IN } from '../consts/jwt.const';
+import { ConfigService } from '@nestjs/config';
+
+@Injectable()
+export class TestService {
+  constructor(
+    private readonly jwtService: JwtService,
+    private readonly configService: ConfigService,
+  ) {}
+
+  issueTestToken(userId: number) {
+    return this.jwtService.sign(
+      { userId },
+      {
+        expiresIn: ACCESS_TOKEN_EXPIRES_IN,
+        secret: this.configService.get('JWT_SECRET'),
+      },
+    );
+  }
+}

--- a/src/libs/utils/respone.entity.ts
+++ b/src/libs/utils/respone.entity.ts
@@ -1,0 +1,78 @@
+import { HttpStatus } from '@nestjs/common';
+import { Exclude, Expose } from 'class-transformer';
+
+export class ResponseEntity<T> {
+  // 존재 이유
+  @Exclude() private readonly _statusCode: HttpStatus; // 상태 코드
+  @Exclude() private readonly _message: string; // 메시지
+  @Exclude() private readonly _data: T; // Controller response data
+
+  private constructor(status: HttpStatus, message: string, data: T) {
+    this._statusCode = status;
+    this._message = message;
+    this._data = data;
+  }
+
+  static OK(): ResponseEntity<string> {
+    return new ResponseEntity<string>(HttpStatus.OK, '', '');
+  }
+
+  static OK_WITH_MESSAGE(message: string): ResponseEntity<string> {
+    return new ResponseEntity<string>(HttpStatus.OK, message, '');
+  }
+
+  static OK_WITH_DATA<T>(data: T): ResponseEntity<T> {
+    return new ResponseEntity<T>(HttpStatus.OK, '', data);
+  }
+
+  static CREATED(): ResponseEntity<string> {
+    return new ResponseEntity<string>(HttpStatus.CREATED, '', '');
+  }
+
+  static CREATED_WITH_MESSAGE(message: string): ResponseEntity<string> {
+    return new ResponseEntity<string>(HttpStatus.CREATED, message, '');
+  }
+
+  static CREATED_WITH_DATA<T>(data: T): ResponseEntity<T> {
+    return new ResponseEntity<T>(HttpStatus.CREATED, '', data);
+  }
+
+  //   static INTERNAL_SERVER_ERROR(): ResponseEntity<string> {
+  //     return new ResponseEntity<string>(HttpStatus.INTERNAL_SERVER_ERROR, '', '');
+  //   }
+
+  //   static INTERNAL_SERVER_ERROR_WITH(message: string): ResponseEntity<string> {
+  //     return new ResponseEntity<string>(
+  //       HttpStatus.INTERNAL_SERVER_ERROR,
+  //       message,
+  //       '',
+  //     );
+  //   }
+
+  //   static INTERNAL_SERVER_ERROR_ERROR_WITH_DATA(data): ResponseEntity<string> {
+  //     return new ResponseEntity<string>(HttpStatus.INTERNAL_SERVER_ERROR, '', '');
+  //   }
+
+  static ERROR<T>(
+    statusCode = HttpStatus.INTERNAL_SERVER_ERROR,
+    message?: string,
+    data?: T,
+  ) {
+    return new ResponseEntity<T>(statusCode, message, data);
+  }
+
+  @Expose()
+  get statusCode(): HttpStatus {
+    return this._statusCode;
+  }
+
+  @Expose()
+  get message(): string {
+    return this._message;
+  }
+
+  @Expose()
+  get data(): T {
+    return this._data;
+  }
+}

--- a/src/libs/utils/respone.entity.ts
+++ b/src/libs/utils/respone.entity.ts
@@ -2,7 +2,6 @@ import { HttpStatus } from '@nestjs/common';
 import { Exclude, Expose } from 'class-transformer';
 
 export class ResponseEntity<T> {
-  // 존재 이유
   @Exclude() private readonly _statusCode: HttpStatus; // 상태 코드
   @Exclude() private readonly _message: string; // 메시지
   @Exclude() private readonly _data: T; // Controller response data
@@ -36,22 +35,6 @@ export class ResponseEntity<T> {
   static CREATED_WITH_DATA<T>(data: T): ResponseEntity<T> {
     return new ResponseEntity<T>(HttpStatus.CREATED, '', data);
   }
-
-  //   static INTERNAL_SERVER_ERROR(): ResponseEntity<string> {
-  //     return new ResponseEntity<string>(HttpStatus.INTERNAL_SERVER_ERROR, '', '');
-  //   }
-
-  //   static INTERNAL_SERVER_ERROR_WITH(message: string): ResponseEntity<string> {
-  //     return new ResponseEntity<string>(
-  //       HttpStatus.INTERNAL_SERVER_ERROR,
-  //       message,
-  //       '',
-  //     );
-  //   }
-
-  //   static INTERNAL_SERVER_ERROR_ERROR_WITH_DATA(data): ResponseEntity<string> {
-  //     return new ResponseEntity<string>(HttpStatus.INTERNAL_SERVER_ERROR, '', '');
-  //   }
 
   static ERROR<T>(
     statusCode = HttpStatus.INTERNAL_SERVER_ERROR,

--- a/src/modules/database/repositories/abstract.repository.ts
+++ b/src/modules/database/repositories/abstract.repository.ts
@@ -1,0 +1,71 @@
+type Operations =
+  | 'aggregate'
+  | 'count'
+  | 'create'
+  | 'createMany'
+  | 'delete'
+  | 'deleteMany'
+  | 'findFirst'
+  | 'findMany'
+  | 'findUnique'
+  | 'update'
+  | 'updateMany'
+  | 'upsert';
+
+export class AbstractRepository<
+  Db extends { [Key in Operations]: (data: any) => unknown },
+  Args extends { [K in Operations]: unknown },
+  Return extends { [K in Operations]: unknown },
+> {
+  constructor(protected db: Db) {}
+
+  findFirst(data?: Args['findFirst']): Return['findFirst'] {
+    return this.db.findFirst(data);
+  }
+
+  findUnique(data: Args['findUnique']): Return['findUnique'] {
+    return this.db.findUnique(data);
+  }
+
+  findMany(data?: Args['findMany']): Return['findMany'] {
+    return this.db.findMany(data);
+  }
+
+  create(data: Args['create']): Return['create'] {
+    return this.db.create(data);
+  }
+
+  createMany(data: Args['createMany']): Return['createMany'] {
+    return this.db.createMany(data);
+  }
+
+  update(data: Args['update']): Return['update'] {
+    return this.db.update(data);
+  }
+
+  updateMany(data: Args['updateMany']): Return['updateMany'] {
+    return this.db.updateMany(data);
+  }
+
+  delete(data: Args['delete']): Return['delete'] {
+    return this.db.delete(data);
+  }
+
+  deleteMany(data?: Args['deleteMany']): Return['deleteMany'] {
+    return this.db.deleteMany(data);
+  }
+
+  count(data?: Args['count']): Return['count'] {
+    return this.db.count(data);
+  }
+}
+
+export type DelegateArgs<T> = {
+  [Key in keyof T]: T[Key] extends (args: infer A) => unknown ? A : never;
+};
+
+export type DelegateReturnTypes<T> = {
+  [Key in keyof T]: T[Key] extends (...args: any[]) => any
+    ? ReturnType<T[Key]>
+    : never;
+};

--- a/src/modules/database/repositories/resume.repository.ts
+++ b/src/modules/database/repositories/resume.repository.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@nestjs/common';
+import {
+  AbstractRepository,
+  DelegateArgs,
+  DelegateReturnTypes,
+} from './abstract.repository';
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '../prisma.service';
+
+type ResumeDelegate = Prisma.ResumeDelegate<
+  Prisma.RejectOnNotFound | Prisma.RejectPerOperation | undefined
+>;
+
+@Injectable()
+export class ResumesRepository extends AbstractRepository<
+  ResumeDelegate,
+  DelegateArgs<ResumeDelegate>,
+  DelegateReturnTypes<ResumeDelegate>
+> {
+  constructor(private readonly prisma: PrismaService) {
+    super(prisma.resume);
+  }
+}


### PR DESCRIPTION
## 추상 레포지터리 설정

#37 에서의 기능을 추가했습니다.
- 추가로 findMany 등의 메서드를 작성하지 않아도, 추상 레포지터리를 구현하면 별도 메서드 추가 없이 사용 가능

## 응답 엔티티 추가
- 응답을 일관되게 전달하기 위해서 응답 엔티티를 추가했습니다.
- 에러 메시지에 대한 응답 엔티티는 별도 추가가 필요해보입니다.(현재 구현된 소스코드로는 에러 발생 시의 응답과, 2xx 상태의 응답의 형태가 다릅니다)
<img width="431" alt="image" src="https://github.com/depromeet/13th-4team-backend/assets/83271772/7a6a78e0-3b5a-4d2d-86e7-4a141b59c619">
<img width="889" alt="image" src="https://github.com/depromeet/13th-4team-backend/assets/83271772/64698633-4a5c-41ef-a041-b35ec0cb49bb">

물론 사용하지 않아도 좋습니다!

## 테스트용 액세스토큰 발급

POST /test/token
```ts
// request body
{
  "userId": number
}
````
테스트 토큰 발급 api의 바디에 userId를 넣어서 액세스 토큰을 발급받습니다. 테스트하기 용이하게 하려고 만들었어요.

## 자기소개서 조회 api 추가

레포지터리 테스트하려고 만들었는데 그냥 써도 괜찮을 것 같아요..? 아니면 쿼리를 조금 수정해야 할 수도..?