### PR TITLE
[Fix] token 발급 방식에서의 오류 수정, 테스트 refresh 토큰 발급 추가

### DIFF
--- a/src/apps/server/auth/auth.service.ts
+++ b/src/apps/server/auth/auth.service.ts
@@ -82,7 +82,7 @@ export class AuthService {
       { userId },
       {
         secret: this.configService.get<string>('JWT_SECRET'),
-        expiresIn: ACCESS_TOKEN_EXPIRES_IN * 1000,
+        expiresIn: REFRESH_TOKEN_EXPIRES_IN * 1000,
       },
     );
   }

--- a/src/apps/server/auth/auth.service.ts
+++ b/src/apps/server/auth/auth.service.ts
@@ -81,7 +81,7 @@ export class AuthService {
     return this.jwtService.sign(
       { userId },
       {
-        secret: this.configService.get<string>('JWT_REFRESH_TOKEN_SECRET'),
+        secret: this.configService.get<string>('JWT_SECRET'),
         expiresIn: ACCESS_TOKEN_EXPIRES_IN * 1000,
       },
     );

--- a/src/apps/server/auth/auth.service.ts
+++ b/src/apps/server/auth/auth.service.ts
@@ -72,7 +72,7 @@ export class AuthService {
       { userId },
       {
         secret: this.configService.get<string>('JWT_SECRET'),
-        expiresIn: ACCESS_TOKEN_EXPIRES_IN * 1000,
+        expiresIn: ACCESS_TOKEN_EXPIRES_IN,
       },
     );
   }
@@ -82,7 +82,7 @@ export class AuthService {
       { userId },
       {
         secret: this.configService.get<string>('JWT_SECRET'),
-        expiresIn: REFRESH_TOKEN_EXPIRES_IN * 1000,
+        expiresIn: REFRESH_TOKEN_EXPIRES_IN,
       },
     );
   }

--- a/src/apps/server/test/test.controller.ts
+++ b/src/apps/server/test/test.controller.ts
@@ -1,15 +1,24 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Post, Res } from '@nestjs/common';
 import { TestService } from './test.service';
 import { ResponseEntity } from '../../../libs/utils/respone.entity';
+import { Response } from 'express';
+import { ACCESS_TOKEN_EXPIRES_IN } from '../consts/jwt.const';
 
 @Controller('test')
 export class TestController {
   constructor(private readonly testService: TestService) {}
 
   @Post('token')
-  issueTestToken(@Body() { userId }: { userId: number }) {
-    return ResponseEntity.CREATED_WITH_DATA(
-      this.testService.issueTestToken(userId),
-    );
+  async issueTestToken(
+    @Body() { userId }: { userId: number },
+    @Res({ passthrough: true }) response: Response,
+  ) {
+    const jwtToken = await this.testService.issueTestToken(userId);
+
+    response.cookie('refreshToken', jwtToken, {
+      maxAge: ACCESS_TOKEN_EXPIRES_IN * 1000,
+      httpOnly: true,
+    });
+    return ResponseEntity.CREATED_WITH_DATA(jwtToken);
   }
 }

--- a/src/apps/server/test/test.module.ts
+++ b/src/apps/server/test/test.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { TestController } from './test.controller';
 import { TestService } from './test.service';
 import { JwtModule } from '@nestjs/jwt';
+import { RedisCacheModule } from '../../../modules/cache/redis/redis.module';
 
 @Module({
-  imports: [JwtModule],
+  imports: [JwtModule, RedisCacheModule],
   controllers: [TestController],
   providers: [TestService],
 })

--- a/src/apps/server/test/test.service.ts
+++ b/src/apps/server/test/test.service.ts
@@ -2,21 +2,25 @@ import { Injectable } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { ACCESS_TOKEN_EXPIRES_IN } from '../consts/jwt.const';
 import { ConfigService } from '@nestjs/config';
+import { RedisCacheService } from '../../../modules/cache/redis/redis.service';
 
 @Injectable()
 export class TestService {
   constructor(
+    private readonly redisService: RedisCacheService,
     private readonly jwtService: JwtService,
     private readonly configService: ConfigService,
   ) {}
 
-  issueTestToken(userId: number) {
-    return this.jwtService.sign(
+  async issueTestToken(userId: number) {
+    const token = this.jwtService.sign(
       { userId },
       {
         expiresIn: ACCESS_TOKEN_EXPIRES_IN,
         secret: this.configService.get('JWT_SECRET'),
       },
     );
+    await this.redisService.set(String(userId), token);
+    return token;
   }
 }


### PR DESCRIPTION
# Jwt 오류 수정

- 실수로 환경변수를 잘못 기입해서 수정했습니다.
- 리프레시 토큰의 만료 기한이 액세스 토큰과 같은 값을 가지고 있었고, 단위가 ms가 아니라 s라서 1000 곱한 것을 제거했습니다.