### PR TITLE
[Feature] Swagger 설정을 공통으로 적용

### DIFF
--- a/src/apps/server/main.ts
+++ b/src/apps/server/main.ts
@@ -5,7 +5,6 @@ import { EnvEnum } from '📚libs/modules/env/env.enum';
 import { EnvService } from '📚libs/modules/env/env.service';
 import { AppModule } from './app.module';
 import cookieParser from 'cookie-parser';
-import { NodeEnvEnum } from '📚libs/enums/node-env.enum';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -14,32 +13,19 @@ async function bootstrap() {
 
   //환경변수 가져오기
   const envService = app.get(EnvService);
-  const NODE_ENV = envService.get<NodeEnvEnum>(EnvEnum.NODE_ENV);
   const PORT = +envService.get(EnvEnum.PORT) || 3000;
 
-  //Swagger
-  switch (NODE_ENV) {
-    case NodeEnvEnum.Dev:
-      (() => {
-        const config = new DocumentBuilder()
-          .setTitle('13기 4팀 서버')
-          .setDescription('자기소개서 관리 시스템 🚨🚨🚨🚨 모든 성공 response 값은 메세지 또는 data 프로퍼티 안에 있습니다.🚨🚨🚨')
-          .addServer(`http://localhost:${envService.get(EnvEnum.PORT)}`, '로컬서버')
-          .addServer(`${envService.get(EnvEnum.DEV_SERVER)}:${envService.get(EnvEnum.PORT)}`, '개발서버')
-          .addServer(`${envService.get(EnvEnum.STAGE_SERVER)}:${envService.get(EnvEnum.PORT)}`, '스테이트서버')
-          .addServer(`${envService.get(EnvEnum.MAIN_SERVER)}:${envService.get(EnvEnum.PORT)}`, '운영서버')
+  const config = new DocumentBuilder()
+    .setTitle('13기 4팀 서버')
+    .setDescription('자기소개서 관리 시스템 🚨🚨🚨🚨 모든 성공 response 값은 메세지 또는 data 프로퍼티 안에 있습니다.🚨🚨🚨')
+    .addServer(`${envService.get(EnvEnum.DEV_SERVER)}:${envService.get(EnvEnum.PORT)}`, '개발서버')
+    .addServer(`http://localhost:${envService.get(EnvEnum.PORT)}`, '로컬서버')
 
-          .addBearerAuth()
-          .build();
+    .addBearerAuth()
+    .build();
 
-        const document = SwaggerModule.createDocument(app, config);
-        SwaggerModule.setup('api', app, document);
-      })();
-      break;
-    case NodeEnvEnum.Test:
-    case NodeEnvEnum.Main:
-      break;
-  }
+  const document = SwaggerModule.createDocument(app, config);
+  SwaggerModule.setup('api', app, document);
 
   //Winston
   app.useLogger(app.get(WINSTON_MODULE_NEST_PROVIDER));


### PR DESCRIPTION
## ⛳️ 기능 구현 배경

---

<!-- 기능 구현 배경에 대해 작성해주세요 -->

ec2에서 build 할 때 무중단 서버 실행을 위해서 pm2로 서버를 구동하는데, 이게 명령어를 달리 해서 swagger가 뜨지 않습니다. 그래서 스웨거를 별도로 분기처리 하지 않고 공통으로 쓸 수 있도록 하고자 합니다.

## 😤 기능 구현 내용(Optional)

---

<!-- 기능 구현 내용에 대해 적어주세요 -->

### 작업 전

```ts
  //Swagger
  switch (NODE_ENV) {
    case NodeEnvEnum.Dev:
      (() => {
        const config = new DocumentBuilder()
          .setTitle('13기 4팀 서버')
          .setDescription('자기소개서 관리 시스템 🚨🚨🚨🚨 모든 성공 response 값은 메세지 또는 data 프로퍼티 안에 있습니다.🚨🚨🚨')
          .addServer(`http://localhost:${envService.get(EnvEnum.PORT)}`, '로컬서버')
          .addServer(`${envService.get(EnvEnum.DEV_SERVER)}:${envService.get(EnvEnum.PORT)}`, '개발서버')
          .addServer(`${envService.get(EnvEnum.STAGE_SERVER)}:${envService.get(EnvEnum.PORT)}`, '스테이트서버')
          .addServer(`${envService.get(EnvEnum.MAIN_SERVER)}:${envService.get(EnvEnum.PORT)}`, '운영서버')

          .addBearerAuth()
          .build();

        const document = SwaggerModule.createDocument(app, config);
        SwaggerModule.setup('api', app, document);
      })();
      break;
    case NodeEnvEnum.Test:
    case NodeEnvEnum.Main:
      break;
  }
```

### 작업 후

```ts
  const config = new DocumentBuilder()
    .setTitle('13기 4팀 서버')
    .setDescription('자기소개서 관리 시스템 🚨🚨🚨🚨 모든 성공 response 값은 메세지 또는 data 프로퍼티 안에 있습니다.🚨🚨🚨')
    .addServer(`${envService.get(EnvEnum.DEV_SERVER)}:${envService.get(EnvEnum.PORT)}`, '개발서버')
    .addServer(`http://localhost:${envService.get(EnvEnum.PORT)}`, '로컬서버')

    .addBearerAuth()
    .build();

  const document = SwaggerModule.createDocument(app, config);
  SwaggerModule.setup('api', app, document);
```

## 📭 이슈 번호

---

<!-- 이슈 번호를 남겨주세요 -->

Resolves: #81

## 🧐 의견 구하기

---

<!-- 구하고 싶은 의견이 있다면 작성해주세요 -->

이것저것 많이 바뀌네요 ㅜㅜ 죄송해요 동현님...

## 🙏 P.S

---

<!-- 추가적으로 남기고 싶은 말을 적어주세요 -->

아래 사이트에서 접속 가능합니다! 아직은 http 프로토콜만 열어놨어요