### PR TITLE
[Feature] 자기소개서 단일 조회 API 추가 및 자기소개서 API 관련 리팩터링, 자기소개서 조회 관련 명세 추가

### DIFF
--- a/src/apps/server/main.ts
+++ b/src/apps/server/main.ts
@@ -20,7 +20,12 @@ async function bootstrap() {
     .setDescription('자기소개서 관리 시스템 🚨🚨🚨🚨 모든 성공 response 값은 메세지 또는 data 프로퍼티 안에 있습니다.🚨🚨🚨')
     .addServer(`${envService.get(EnvEnum.DEV_SERVER)}`, '개발서버')
     .addServer(`http://localhost:${envService.get(EnvEnum.PORT)}`, '로컬서버')
-
+    .addSecurity('bearer', {
+      type: 'http',
+      scheme: 'bearer',
+      bearerFormat: 'JWT',
+    })
+    .addSecurityRequirements('bearer')
     .addBearerAuth()
     .build();
 

--- a/src/apps/server/resumes/controllers/question.controller.ts
+++ b/src/apps/server/resumes/controllers/question.controller.ts
@@ -7,7 +7,7 @@ import { RouteTable } from '🔥apps/server/common/decorators/router/route-table
 import { Route } from '🔥apps/server/common/decorators/router/route.decorator';
 import { JwtAuthGuard } from '🔥apps/server/common/guards/jwt-auth.guard';
 import { PatchQuestionRequestParamDto, PatchQuestionRequestBodyDto } from '🔥apps/server/resumes/dtos/patch-question-request.dto';
-import { PostQuestionResponseDto, PostQuestionRequestParamDto } from '🔥apps/server/resumes/dtos/post-question.dto';
+import { PostQuestionResponseDto, PostQuestionRequestBodyDto } from '🔥apps/server/resumes/dtos/post-question.dto';
 import { QuestionsService } from '🔥apps/server/resumes/services/question.service';
 
 @RouteTable({
@@ -22,7 +22,7 @@ export class QuestionsController {
 
   @Route({
     request: {
-      path: ':resumeId',
+      path: '',
       method: Method.POST,
     },
     response: {
@@ -33,7 +33,7 @@ export class QuestionsController {
     description: '자기소개서 폴더 아래 문항 추가 버튼을 눌러서 문항을 추가합니다. 빈 문항만 추가됩니다.',
   })
   async createOneQuestion(
-    @Param() postQuestionRequestParamDto: PostQuestionRequestParamDto,
+    @Body() postQuestionRequestParamDto: PostQuestionRequestBodyDto,
     @User() user: UserJwtToken,
   ): Promise<ResponseEntity<PostQuestionResponseDto>> {
     const question = await this.questionService.createOneQuestion(user.userId, postQuestionRequestParamDto.resumeId);

--- a/src/apps/server/resumes/controllers/resumes.controller.ts
+++ b/src/apps/server/resumes/controllers/resumes.controller.ts
@@ -29,8 +29,8 @@ export class ResumesController {
       type: GetResumeResponseDto,
       isArray: true,
     },
-    summary: '자기소개서 조회 API',
-    description: `# 자기소개서 조회 API\n## Description\n자기소개서를 처음 조회했을 때, 자기소개서 목록과 각 자기소개서 별 문항을 모두 출력합니다.\n## Keyword\n용어가 통일되지 않아 명세합니다.\n1. 자기소개서: 디프만 13기\n2. 문항: 디프만 13기 지원 동기   \n## etc.\n⛳️[자기소개서 작성 첫 화면](https://www.figma.com/file/0ZJ1ulwtU8k0KQuroxU9Wc/%EC%9D%B8%EC%82%AC%EC%9D%B4%ED%8A%B8%EC%95%84%EC%9B%83?type=design&node-id=1221-8169&t=bY8GHCeIQEeC8L6e-4)
+    summary: '자기소개서 조회 API (2023.6.3. Updated)',
+    description: `# 자기소개서 조회 API\n## Description\n자기소개서를 조회합니다., 자기소개서 목록과 각 자기소개서 별 문항을 모두 출력합니다.   \n문항에 대한 답안이 payload가 크기 때문에 기본적으로 문항 제목만 조회하며, answer 쿼리스트링 값에 따라서 문항에 대한 답안도 추가적으로 가져옵니다.   \n\`\`\`ts\nconsole.log('hello world!')\n\`\`\`  \n## Keyword\n용어가 통일되지 않아 명세합니다.\n1. 자기소개서: 디프만 13기\n2. 문항: 디프만 13기 지원 동기   \n## etc.\n⛳️[자기소개서 작성 첫 화면](https://www.figma.com/file/0ZJ1ulwtU8k0KQuroxU9Wc/%EC%9D%B8%EC%82%AC%EC%9D%B4%ED%8A%B8%EC%95%84%EC%9B%83?type=design&node-id=1221-8169&t=bY8GHCeIQEeC8L6e-4)
       `,
   })
   @ApiQuery({

--- a/src/apps/server/resumes/controllers/resumes.controller.ts
+++ b/src/apps/server/resumes/controllers/resumes.controller.ts
@@ -9,7 +9,7 @@ import { Route } from '🔥apps/server/common/decorators/router/route.decorator'
 import { JwtAuthGuard } from '🔥apps/server/common/guards/jwt-auth.guard';
 import { GetResumeRequestQueryDto, GetResumeResponseDto } from '🔥apps/server/resumes/dtos/get-resume.dto';
 import { PatchResumeRequestDto } from '🔥apps/server/resumes/dtos/patch-resume.dto';
-import { PostResumeRequestBodyDto, PostResumeResponseDto } from '🔥apps/server/resumes/dtos/post-resume.dto';
+import { PostResumeResponseDto } from '🔥apps/server/resumes/dtos/post-resume.dto';
 import { PostSpellCheckRequestBodyDto } from '🔥apps/server/resumes/dtos/post-spell-check-request.body.dto';
 import { ResumesService } from '🔥apps/server/resumes/services/resumes.service';
 
@@ -58,13 +58,10 @@ export class ResumesController {
     },
     summary: '자기소개서 추가 API',
     description:
-      '# 자기소개서 추가 API\n## Description\n새로 추가 버튼을 눌러 자기소개서를 추가합니다.\n## etc.\n⛳️[새 폴더 추가한 경우](https://www.figma.com/file/0ZJ1ulwtU8k0KQuroxU9Wc/%EC%9D%B8%EC%82%AC%EC%9D%B4%ED%8A%B8%EC%95%84%EC%9B%83?type=design&node-id=1221-8662&t=zKwSWoPmdDHGzQV4-4)',
+      '# 자기소개서 추가 API\n## Description\n새로 추가 버튼을 눌러 자기소개서를 추가합니다. 단순히 추가하는 것이므로 별도로 **request body가 필요하지 않습니다**. 기본적으로 **"새 자기소개서"**라는 제목으로 추가됩니다.\n## Picture\n![image](https://github.com/depromeet/13th-4team-backend/assets/83271772/480c339f-f8eb-4960-a0a2-59162193a2d8)\n## Figma\n⛳️[새 폴더 추가한 경우](https://www.figma.com/file/0ZJ1ulwtU8k0KQuroxU9Wc/%EC%9D%B8%EC%82%AC%EC%9D%B4%ED%8A%B8%EC%95%84%EC%9B%83?type=design&node-id=1221-8662&t=zKwSWoPmdDHGzQV4-4)',
   })
-  async createResumeFolder(
-    @Body() postResumeRequestBodyDto: PostResumeRequestBodyDto,
-    @User() user: UserJwtToken,
-  ): Promise<ResponseEntity<PostResumeResponseDto>> {
-    const resume = await this.resumesService.createResumeFolder(postResumeRequestBodyDto, user.userId);
+  async createResumeFolder(@User() user: UserJwtToken): Promise<ResponseEntity<PostResumeResponseDto>> {
+    const resume = await this.resumesService.createResumeFolder(user.userId);
 
     return ResponseEntity.CREATED_WITH_DATA(resume);
   }

--- a/src/apps/server/resumes/controllers/resumes.controller.ts
+++ b/src/apps/server/resumes/controllers/resumes.controller.ts
@@ -30,7 +30,7 @@ export class ResumesController {
       isArray: true,
     },
     summary: '자기소개서 조회 API (2023.6.3. Updated)',
-    description: `# 자기소개서 조회 API\n## Description\n자기소개서를 조회합니다., 자기소개서 목록과 각 자기소개서 별 문항을 모두 출력합니다.   \n문항에 대한 답안이 payload가 크기 때문에 기본적으로 문항 제목만 조회하며, answer 쿼리스트링 값에 따라서 문항에 대한 답안도 추가적으로 가져옵니다.   \n\`\`\`ts\nconsole.log('hello world!')\n\`\`\`  \n## Keyword\n용어가 통일되지 않아 명세합니다.\n1. 자기소개서: 디프만 13기\n2. 문항: 디프만 13기 지원 동기   \n## etc.\n⛳️[자기소개서 작성 첫 화면](https://www.figma.com/file/0ZJ1ulwtU8k0KQuroxU9Wc/%EC%9D%B8%EC%82%AC%EC%9D%B4%ED%8A%B8%EC%95%84%EC%9B%83?type=design&node-id=1221-8169&t=bY8GHCeIQEeC8L6e-4)
+    description: `# 자기소개서 조회 API\n## Description\n자기소개서를 조회합니다., 자기소개서 목록과 각 자기소개서 별 문항을 모두 출력합니다.   \n문항에 대한 답안이 payload가 크기 때문에 기본적으로 문항 제목만 조회하며, answer 쿼리스트링 값에 따라서 문항에 대한 답안도 추가적으로 가져옵니다.\n- POST /resumes - 자기소개서(Resumes)와 문항들(Questions)을 가져오며, 문항의 답안(answer)은 가져오지 않습니다.\n- POST /resumes?answer=true - 자기소개서(Resumes)와 문항들(Questions)을 가져오며, 자기소개서 문항의 제목과 답안을 가져옵니다.\n## Keyword\n용어가 통일되지 않아 명세합니다.\n1. 자기소개서: 디프만 13기\n2. 문항: 디프만 13기 지원 동기   \n## etc.\n⛳️[자기소개서 작성 첫 화면](https://www.figma.com/file/0ZJ1ulwtU8k0KQuroxU9Wc/%EC%9D%B8%EC%82%AC%EC%9D%B4%ED%8A%B8%EC%95%84%EC%9B%83?type=design&node-id=1221-8169&t=bY8GHCeIQEeC8L6e-4)
       `,
   })
   @ApiQuery({

--- a/src/apps/server/resumes/controllers/resumes.controller.ts
+++ b/src/apps/server/resumes/controllers/resumes.controller.ts
@@ -7,13 +7,18 @@ import { UserJwtToken } from '🔥apps/server/auth/types/jwt-tokwn.type';
 import { User } from '🔥apps/server/common/decorators/request/user.decorator';
 import { Route } from '🔥apps/server/common/decorators/router/route.decorator';
 import { JwtAuthGuard } from '🔥apps/server/common/guards/jwt-auth.guard';
-import { GetResumeRequestQueryDto, GetResumeResponseDto } from '🔥apps/server/resumes/dtos/get-resume.dto';
+import {
+  GetAllResumeRequestQueryDto,
+  GetAllResumeResponseDto,
+  GetOneResumeRequestParamDto,
+  GetOneResumeResponseDto,
+} from '🔥apps/server/resumes/dtos/get-resume.dto';
 import { PatchResumeRequestDto } from '🔥apps/server/resumes/dtos/patch-resume.dto';
 import { PostResumeResponseDto } from '🔥apps/server/resumes/dtos/post-resume.dto';
 import { PostSpellCheckRequestBodyDto } from '🔥apps/server/resumes/dtos/post-spell-check-request.body.dto';
 import { ResumesService } from '🔥apps/server/resumes/services/resumes.service';
 
-@ApiTags('resumes')
+@ApiTags('🗂️ 자기소개서 API')
 @UseGuards(JwtAuthGuard)
 @Controller('resumes')
 export class ResumesController {
@@ -26,24 +31,49 @@ export class ResumesController {
     },
     response: {
       code: HttpStatus.OK,
-      type: GetResumeResponseDto,
+      type: GetAllResumeResponseDto,
       isArray: true,
+      description:
+        '### ✅ 자기소개서 전체 조회에 성공했습니다.\n유저가 작성한 모든 자기소개서를 반환하며, 각각의 자기소개서는 문항을 포함하고 문항의 답안은 Optional로 선택하여 가져올 수 있습니다.   \n자기소개서가 출력되는 기준은 모두 생성일자로부터 내림차순입니다. 자기소개서에 속한 자기소개서 문항도 마찬가지입니다.',
     },
-    summary: '자기소개서 조회 API (2023.6.3. Updated)',
-    description: `# 자기소개서 조회 API\n## Description\n자기소개서를 조회합니다., 자기소개서 목록과 각 자기소개서 별 문항을 모두 출력합니다.   \n문항에 대한 답안이 payload가 크기 때문에 기본적으로 문항 제목만 조회하며, answer 쿼리스트링 값에 따라서 문항에 대한 답안도 추가적으로 가져옵니다.\n- POST /resumes - 자기소개서(Resumes)와 문항들(Questions)을 가져오며, 문항의 답안(answer)은 가져오지 않습니다.\n- POST /resumes?answer=true - 자기소개서(Resumes)와 문항들(Questions)을 가져오며, 자기소개서 문항의 제목과 답안을 가져옵니다.\n## Keyword\n용어가 통일되지 않아 명세합니다.\n1. 자기소개서: 디프만 13기\n2. 문항: 디프만 13기 지원 동기   \n## etc.\n⛳️[자기소개서 작성 첫 화면](https://www.figma.com/file/0ZJ1ulwtU8k0KQuroxU9Wc/%EC%9D%B8%EC%82%AC%EC%9D%B4%ED%8A%B8%EC%95%84%EC%9B%83?type=design&node-id=1221-8169&t=bY8GHCeIQEeC8L6e-4)
+    summary: '자기소개서 전체 조회 API (2023.6.3. Updated)',
+    description: `# 자기소개서 조회 API\n## Description\n자기소개서를 생성한 날짜 기준 내림차순(최신순)으로 조회합니다. 자기소개서 목록과 각 자기소개서 별 문항을 모두 출력합니다.   \n문항에 대한 답안이 payload가 크기 때문에 기본적으로 문항 제목만 조회하며, answer 쿼리스트링 값에 따라서 문항에 대한 답안도 추가적으로 가져옵니다.\n- POST /resumes - 자기소개서(Resumes)와 문항들(Questions)을 가져오며, 문항의 답안(answer)은 가져오지 않습니다.\n- POST /resumes?answer=true - 자기소개서(Resumes)와 문항들(Questions)을 가져오며, 자기소개서 문항의 제목과 답안을 가져옵니다.\n## Keyword\n용어가 통일되지 않아 명세합니다.\n1. 자기소개서: 디프만 13기\n2. 문항: 디프만 13기 지원 동기\n## Picture\n![image](https://github.com/depromeet/13th-4team-backend/assets/83271772/61edf279-1e15-46de-a974-561eac58b4a3)\n\n## Figma.\n⛳️[자기소개서 작성 첫 화면](https://www.figma.com/file/0ZJ1ulwtU8k0KQuroxU9Wc/%EC%9D%B8%EC%82%AC%EC%9D%B4%ED%8A%B8%EC%95%84%EC%9B%83?type=design&node-id=1221-8169&t=bY8GHCeIQEeC8L6e-4)
       `,
   })
   @ApiQuery({
     description: '자기소개서를 조회할 때 사용할 쿼리입니다. false를 입력 시 자기소개서만 조회하고, true를 입력 시 문항도 함께 조회합니다.',
-    type: GetResumeRequestQueryDto,
+    type: GetAllResumeRequestQueryDto,
   })
   async getAllResumes(
     @User() user: UserJwtToken,
-    @Query() query: GetResumeRequestQueryDto,
-  ): Promise<ResponseEntity<GetResumeResponseDto[]>> {
-    const resumes = await this.resumesService.getAllResumes(user.userId, query);
+    @Query() getAllResumeRequestQueryDto: GetAllResumeRequestQueryDto,
+  ): Promise<ResponseEntity<GetAllResumeResponseDto>> {
+    const resumes = await this.resumesService.getAllResumes(user.userId, getAllResumeRequestQueryDto);
 
     return ResponseEntity.OK_WITH_DATA(resumes);
+  }
+
+  @Route({
+    request: {
+      path: ':resumeId',
+      method: Method.GET,
+    },
+    response: {
+      code: HttpStatus.OK,
+      type: GetOneResumeResponseDto,
+      description:
+        '### ✅ 특정 자기소개서 조회에 성공했습니다.\n한 개의 자기소개서를 가져오며, 자기소개서에 속한 자기소개서 문항도 생성일자 기준 내림차순으로 가져옵니다.',
+    },
+    summary: '특정 자기소개서 조회 API (2023.6.3. Updated)',
+    description: `# 자기소개서 조회 API\n## Description\n**userId**와 **resumeId** path parameter를 통해서 특정 자기소개서 한 개를 조회합니다. 자기소개서는 그 자기소개서에 속한 모든 문항를 가져옵니다.   \n자기소개서 문항은 **생성일자 기준 내림차순(최신순)으로 정렬**되어 출력됩니다. 주로 \`모아보기\`에서 사용됩니다.\n## Picture\n![image](https://github.com/depromeet/13th-4team-backend/assets/83271772/90712fb4-7c1e-4b8c-845e-2139dd6deca9)\n## Figma.\n⛳️ [자기소개서 모아보기](https://www.figma.com/file/0ZJ1ulwtU8k0KQuroxU9Wc/%EC%9D%B8%EC%82%AC%EC%9D%B4%ED%8A%B8%EC%95%84%EC%9B%83?type=design&node-id=1403-11728&t=oMTkLrgQjXJOPb8D-4)`,
+  })
+  public async getOneResume(
+    @User() user: UserJwtToken,
+    @Param() getOneResumeRequestParamDto: GetOneResumeRequestParamDto,
+  ): Promise<ResponseEntity<GetOneResumeResponseDto>> {
+    const resume = await this.resumesService.getOneResume(user.userId, getOneResumeRequestParamDto.resumeId);
+
+    return ResponseEntity.OK_WITH_DATA(resume);
   }
 
   @Route({
@@ -56,7 +86,7 @@ export class ResumesController {
       description: '자기소개서 추가에 성공했습니다.',
       type: PostResumeResponseDto,
     },
-    summary: '자기소개서 추가 API',
+    summary: '자기소개서 추가 API (2023.6.3. Updated)',
     description:
       '# 자기소개서 추가 API\n## Description\n새로 추가 버튼을 눌러 자기소개서를 추가합니다. 단순히 추가하는 것이므로 별도로 **request body가 필요하지 않습니다**. 기본적으로 **"새 자기소개서"**라는 제목으로 추가됩니다.\n## Picture\n![image](https://github.com/depromeet/13th-4team-backend/assets/83271772/480c339f-f8eb-4960-a0a2-59162193a2d8)\n## Figma\n⛳️[새 폴더 추가한 경우](https://www.figma.com/file/0ZJ1ulwtU8k0KQuroxU9Wc/%EC%9D%B8%EC%82%AC%EC%9D%B4%ED%8A%B8%EC%95%84%EC%9B%83?type=design&node-id=1221-8662&t=zKwSWoPmdDHGzQV4-4)',
   })

--- a/src/apps/server/resumes/dtos/get-resume.dto.ts
+++ b/src/apps/server/resumes/dtos/get-resume.dto.ts
@@ -3,7 +3,20 @@ import { Question, Resume } from '@prisma/client';
 import { Exclude, Expose, Transform, Type } from 'class-transformer';
 import { IsArray, IsBoolean, IsDate, IsInt, IsNotEmpty, IsObject, IsOptional, IsPositive, IsString, ValidateNested } from 'class-validator';
 
-export class GetResumeRequestQueryDto {
+export class GetOneResumeRequestParamDto {
+  @ApiProperty({
+    description: '자기소개서 id입니다.',
+    example: 1234,
+    type: Number,
+  })
+  @IsInt()
+  @IsPositive()
+  @IsNotEmpty()
+  @Type(() => Number)
+  resumeId: number;
+}
+
+export class GetAllResumeRequestQueryDto {
   @ApiPropertyOptional({
     description: '자기소개서 문항 조회 유무. false를 입력 시 자기소개서만 조회하고, true를 입력 시 문항도 함께 조회합니다.',
     example: false,
@@ -86,7 +99,7 @@ class QuestionResponse {
   }
 }
 
-export class GetResumeResponseDto {
+export class GetOneResumeResponseDto {
   @Exclude() private readonly _id: number;
   @Exclude() private readonly _title: string;
   @Exclude() private readonly _updatedAt: Date;
@@ -149,3 +162,5 @@ export class GetResumeResponseDto {
     return this._question;
   }
 }
+
+export class GetAllResumeResponseDto extends Array<GetOneResumeResponseDto> {}

--- a/src/apps/server/resumes/dtos/get-resume.dto.ts
+++ b/src/apps/server/resumes/dtos/get-resume.dto.ts
@@ -68,13 +68,14 @@ class QuestionResponse {
     this._title = value;
   }
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: '자기소개서 문항 답안',
     type: String,
     example: '디프만을 통한 빠른 성장',
   })
   @IsString()
   @IsNotEmpty()
+  @IsOptional()
   get answer(): string {
     return this._answer;
   }
@@ -150,7 +151,7 @@ export class GetOneResumeResponseDto {
   }
 
   @Expose()
-  @ApiPropertyOptional({
+  @ApiProperty({
     description: '자기소개서 문항',
     type: QuestionResponse,
   })

--- a/src/apps/server/resumes/dtos/post-question.dto.ts
+++ b/src/apps/server/resumes/dtos/post-question.dto.ts
@@ -3,7 +3,7 @@ import { Question } from '@prisma/client';
 import { Exclude, Expose, Type } from 'class-transformer';
 import { IsInt, IsPositive } from 'class-validator';
 
-export class PostQuestionRequestParamDto {
+export class PostQuestionRequestBodyDto {
   @ApiProperty({
     description: '자기소개서 id',
     example: 123,

--- a/src/apps/server/resumes/dtos/post-resume.dto.ts
+++ b/src/apps/server/resumes/dtos/post-resume.dto.ts
@@ -14,14 +14,12 @@ export class PostResumeRequestBodyDto {
 
 export class PostResumeResponseDto {
   @Exclude() readonly _id: number;
-  @Exclude() readonly _title: string;
   @Exclude() readonly _createdAt: Date;
   @Exclude() readonly _updatedAt: Date;
 
   // Entity -> DTO
   constructor(resume: Resume) {
     this._id = resume.id;
-    this._title = resume.title;
     this._createdAt = resume.createdAt;
     this._updatedAt = resume.updatedAt;
   }
@@ -33,15 +31,6 @@ export class PostResumeResponseDto {
   })
   get id(): number {
     return this._id;
-  }
-
-  @Expose()
-  @ApiProperty({
-    description: '자기소개서 제목입니다. 모아보기에서 해당 제목이 사용됩니다.',
-    example: '디프만 13기',
-  })
-  get title(): string {
-    return this._title;
   }
 
   @Expose()

--- a/src/apps/server/resumes/services/question.service.ts
+++ b/src/apps/server/resumes/services/question.service.ts
@@ -8,20 +8,23 @@ import { PatchQuestionRequestBodyDto } from '🔥apps/server/resumes/dtos/patch-
 export class QuestionsService {
   constructor(private readonly resumeRepository: ResumeRepository, private readonly questionRepository: QuestionRepository) {}
 
+  /**
+   * 자기소개서의 문항을 한 개 생성합니다.
+   *
+   * @param userId 자기소개서 문항(Question)을 작성한 userId 입니다.
+   * @param resumeId 자기소개서의 id 입니다. 자기소개서의 문항이 위치할 곳이므로 id 값이 필요합니다.
+   */
   async createOneQuestion(userId: number, resumeId: number): Promise<PostQuestionResponseDto> {
     const resume = await this.resumeRepository.findFirst({
       where: { id: resumeId, User: { id: userId } },
-      include: { Question: true },
     });
 
     if (!resume) {
       throw new NotFoundException('Resume not found');
     }
 
-    const questionLength = resume['Question'].length;
-
     const question = await this.questionRepository.create({
-      data: { resumeId, title: `${questionLength + 1}번 문항` },
+      data: { resumeId },
     });
 
     const questionReponseDto = new PostQuestionResponseDto(question);

--- a/src/apps/server/resumes/services/resumes.service.ts
+++ b/src/apps/server/resumes/services/resumes.service.ts
@@ -2,7 +2,7 @@ import { ApiService } from '📚libs/modules/api/api.service';
 import { SpellCheckResult } from '📚libs/modules/api/api.type';
 import { ResumeRepository } from '📚libs/modules/database/repositories/resume.repository';
 import { Injectable, NotFoundException } from '@nestjs/common';
-import { GetResumeRequestQueryDto, GetResumeResponseDto } from '🔥apps/server/resumes/dtos/get-resume.dto';
+import { GetAllResumeRequestQueryDto, GetAllResumeResponseDto, GetOneResumeResponseDto } from '🔥apps/server/resumes/dtos/get-resume.dto';
 import { PatchResumeRequestDto } from '🔥apps/server/resumes/dtos/patch-resume.dto';
 import { PostResumeResponseDto } from '🔥apps/server/resumes/dtos/post-resume.dto';
 import { PostSpellCheckRequestBodyDto } from '🔥apps/server/resumes/dtos/post-spell-check-request.body.dto';
@@ -20,17 +20,38 @@ export class ResumesService {
    *
    * @returns 유저가 작성한 자기소개서를 문항과 함께 가져옵니다.
    */
-  public async getAllResumes(userId: number, query?: GetResumeRequestQueryDto): Promise<GetResumeResponseDto[]> {
+  public async getAllResumes(userId: number, query?: GetAllResumeRequestQueryDto): Promise<GetAllResumeResponseDto> {
     const { answer } = query;
 
     // 자기소개서와 문항을 함께 가져옵니다.
-    const resumes = (await this.resumesRepository.findMany({
+    const resumes = await this.resumesRepository.findMany({
       where: { userId },
-      include: { Question: { select: { title: true, answer, updatedAt: true } } }, // 문항의 제목은 모든 화면에서 사용하기 때문에 반드시 true로 지정합니다.
+      include: { Question: { select: { title: true, answer, updatedAt: true }, orderBy: { createdAt: 'desc' } } }, // 문항의 제목은 모든 화면에서 사용하기 때문에 반드시 true로 지정합니다.
       orderBy: { createdAt: 'desc' }, // 기본적으로 DB에서 순서가 바뀌기 때문에 정렬하여 고정적으로 데이터를 반환합니다.
-    })) as (Resume & { Question: Question[] })[]; // Resume 테이블과 Question 타입을 인터섹션한 후에 타입 단언을 통해 해결합니다.
+    }); // Resume 테이블과 Question 타입을 인터섹션한 후에 타입 단언을 통해 해결합니다.
 
-    return resumes.map((resume) => new GetResumeResponseDto(resume));
+    return resumes.map((resume) => new GetOneResumeResponseDto(resume as Resume & { Question: Question[] }));
+  }
+
+  /**
+   * 한 개의 자기소개서를 조회합니다.
+   *
+   * userId와 resumeId로 특정 자기소개서를 한 개 가져오며, 자기소개서에 해당하는 문항들도 가져옵니다.
+   * 기본적으로 화면 단에서 생성일자 기준 내림차순(최신순)으로 정렬됩니다.
+   *
+   * @param userId 유저 id
+   * @param resumeId 자기소개서 id
+   * @returns 자기소개서와 자기소개서 문항을 가져옵니다.
+   */
+  public async getOneResume(userId: number, resumeId: number): Promise<GetOneResumeResponseDto> {
+    const resume = await this.resumesRepository.findFirst({
+      where: { userId, id: resumeId },
+      include: { Question: { select: { title: true, answer: true, updatedAt: true }, orderBy: { createdAt: 'desc' } } }, // 자기소개서 문항을 left join, select 하며, 생성일자 기준 내림차순으로 모두 가져옵니다.
+    });
+
+    // Entity -> DTO
+    const getOneResumeDto = new GetOneResumeResponseDto(resume as Resume & { Question: Question[] });
+    return getOneResumeDto;
   }
 
   /**

--- a/src/apps/server/resumes/services/resumes.service.ts
+++ b/src/apps/server/resumes/services/resumes.service.ts
@@ -4,7 +4,7 @@ import { ResumeRepository } from '📚libs/modules/database/repositories/resume.
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { GetResumeRequestQueryDto, GetResumeResponseDto } from '🔥apps/server/resumes/dtos/get-resume.dto';
 import { PatchResumeRequestDto } from '🔥apps/server/resumes/dtos/patch-resume.dto';
-import { PostResumeRequestBodyDto, PostResumeResponseDto } from '🔥apps/server/resumes/dtos/post-resume.dto';
+import { PostResumeResponseDto } from '🔥apps/server/resumes/dtos/post-resume.dto';
 import { PostSpellCheckRequestBodyDto } from '🔥apps/server/resumes/dtos/post-spell-check-request.body.dto';
 import { Question, Resume } from '@prisma/client';
 
@@ -27,16 +27,24 @@ export class ResumesService {
     const resumes = (await this.resumesRepository.findMany({
       where: { userId },
       include: { Question: { select: { title: true, answer, updatedAt: true } } }, // 문항의 제목은 모든 화면에서 사용하기 때문에 반드시 true로 지정합니다.
-      orderBy: { updatedAt: 'desc' }, // 기본적으로 DB에서 순서가 바뀌기 때문에 정렬하여 고정적으로 데이터를 반환합니다.
+      orderBy: { createdAt: 'desc' }, // 기본적으로 DB에서 순서가 바뀌기 때문에 정렬하여 고정적으로 데이터를 반환합니다.
     })) as (Resume & { Question: Question[] })[]; // Resume 테이블과 Question 타입을 인터섹션한 후에 타입 단언을 통해 해결합니다.
 
     return resumes.map((resume) => new GetResumeResponseDto(resume));
   }
 
-  public async createResumeFolder(body: PostResumeRequestBodyDto, userId: number): Promise<PostResumeResponseDto> {
-    const { title } = body;
+  /**
+   * 자기소개서를 생성합니다.
+   * 자기소개서 추가 버튼을 눌렀을 때, 빈 자기소개서 폴더(실제로 폴더는 아님)가 만들어집니다.
+   *
+   * 기본값은 "새 자기소개서" 입니다.
+   *
+   * @param userId 유저 id
+   * @returns resumeId, title, createdAt, updatedAt
+   */
+  public async createResumeFolder(userId: number): Promise<PostResumeResponseDto> {
     const resume = await this.resumesRepository.create({
-      data: { title, userId },
+      data: { userId },
     });
 
     // Entity -> DTO

--- a/src/apps/server/resumes/services/resumes.service.ts
+++ b/src/apps/server/resumes/services/resumes.service.ts
@@ -6,17 +6,29 @@ import { GetResumeRequestQueryDto, GetResumeResponseDto } from '🔥apps/server/
 import { PatchResumeRequestDto } from '🔥apps/server/resumes/dtos/patch-resume.dto';
 import { PostResumeRequestBodyDto, PostResumeResponseDto } from '🔥apps/server/resumes/dtos/post-resume.dto';
 import { PostSpellCheckRequestBodyDto } from '🔥apps/server/resumes/dtos/post-spell-check-request.body.dto';
+import { Question, Resume } from '@prisma/client';
 
 @Injectable()
 export class ResumesService {
   constructor(private readonly resumesRepository: ResumeRepository, private readonly apiService: ApiService) {}
 
+  /**
+   * 유저가 작성한 모든 자기소개서를 가져옵니다. 문항의 답안(answer)은 payload가 크기 때문에 option으로 선택해 가져옵니다.
+   *
+   * @param userId 유저 id 입니다.
+   * @param query 문항의 답안(answer)를 조회할지에 대한 여부입니다.
+   *
+   * @returns 유저가 작성한 자기소개서를 문항과 함께 가져옵니다.
+   */
   public async getAllResumes(userId: number, query?: GetResumeRequestQueryDto): Promise<GetResumeResponseDto[]> {
-    const resumes = await this.resumesRepository.findMany({
+    const { answer } = query;
+
+    // 자기소개서와 문항을 함께 가져옵니다.
+    const resumes = (await this.resumesRepository.findMany({
       where: { userId },
-      include: { Question: query.question },
-      orderBy: { updatedAt: 'desc' },
-    });
+      include: { Question: { select: { title: true, answer, updatedAt: true } } }, // 문항의 제목은 모든 화면에서 사용하기 때문에 반드시 true로 지정합니다.
+      orderBy: { updatedAt: 'desc' }, // 기본적으로 DB에서 순서가 바뀌기 때문에 정렬하여 고정적으로 데이터를 반환합니다.
+    })) as (Resume & { Question: Question[] })[]; // Resume 테이블과 Question 타입을 인터섹션한 후에 타입 단언을 통해 해결합니다.
 
     return resumes.map((resume) => new GetResumeResponseDto(resume));
   }

--- a/src/libs/modules/database/schema.prisma
+++ b/src/libs/modules/database/schema.prisma
@@ -17,7 +17,7 @@ datasource db {
 model User {
   id       Int    @id @default(autoincrement()) @map("user_id")
   email    String @unique @db.VarChar(100)
-  uid      String @unique @db.VarChar(100) // 구글 uid
+  uid      String @unique @db.Text // 구글 uid
   socialId String @map("social_id") @db.Text
 
   createdAt DateTime  @default(now()) @map("created_at") @db.Timestamptz

--- a/src/libs/modules/database/schema.prisma
+++ b/src/libs/modules/database/schema.prisma
@@ -85,7 +85,7 @@ model UserInfo {
 // 자기소개서 제목
 model Resume {
   id    Int    @id @default(autoincrement())
-  title String @db.VarChar(13) // 자기소개서 제목
+  title String @db.VarChar(13) @default("새 자기소개서") // 자기소개서 제목
 
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz
   updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz
@@ -105,8 +105,8 @@ model Question {
   id       Int @id @default(autoincrement())
   resumeId Int @map("resume_id") // 자기소개서 제목 pfk
 
-  title  String  @db.VarChar(30) // 문항 제목
-  answer String? @db.VarChar(2000) // 문항 내용
+  title  String?  @db.VarChar(300) // 문항 제목
+  answer String? @db.VarChar(2500) // 문항 내용
 
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz
   updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz
@@ -125,7 +125,7 @@ model Question {
 model Experience {
   id Int @id @default(autoincrement()) @map("id") // 경험 id
 
-  title     String?   @db.VarChar(25) // 경험 제목
+  title     String?   @db.VarChar(50) // 경험 제목
   startDate DateTime? @map("start_date") @db.Date // 시작 날짜 type: YYYY-MM
   endDate   DateTime? @map("end_date") @db.Date // 끝 날짜 type: YYYY-MM
 


### PR DESCRIPTION
## ⛳️ 기능 구현 배경

---

<!-- 기능 구현 배경에 대해 작성해주세요 -->

![image](https://github.com/depromeet/13th-4team-backend/assets/83271772/30d1d659-ed0b-4811-b162-71642f811e78)

해당 화면에서 자기소개서 단일 조회가 필요하므로 단일 조회 API를 하나 생성했습니다.

자기소개서 관련 API가 리팩터링이 필요했습니다. RESTful하게 작성하지 않은 부분을 수정했습니다.

자기소개서 조회 관련 명세를 추가했습니다. 화면도 함께 첨부하면서 프론트엔드에서 더 편하게 사용할 수 있도록 했습니다.

## 😤 기능 구현 내용(Optional)

---

<!-- 기능 구현 내용에 대해 적어주세요 -->

### 1. 자기소개서 단일 조회

```ts
  /**
   * 한 개의 자기소개서를 조회합니다.
   *
   * userId와 resumeId로 특정 자기소개서를 한 개 가져오며, 자기소개서에 해당하는 문항들도 가져옵니다.
   * 기본적으로 화면 단에서 생성일자 기준 내림차순(최신순)으로 정렬됩니다.
   *
   * @param userId 유저 id
   * @param resumeId 자기소개서 id
   * @returns 자기소개서와 자기소개서 문항을 가져옵니다.
   */
  public async getOneResume(userId: number, resumeId: number): Promise<GetOneResumeResponseDto> {
    const resume = await this.resumesRepository.findFirst({
      where: { userId, id: resumeId },
      include: { Question: { select: { title: true, answer: true, updatedAt: true }, orderBy: { createdAt: 'desc' } } }, // 자기소개서 문항을 left join, select 하며, 생성일자 기준 내림차순으로 모두 가져옵니다.
    });

    // Entity -> DTO
    const getOneResumeDto = new GetOneResumeResponseDto(resume as Resume & { Question: Question[] });
    return getOneResumeDto;
  }
````

### 2. 자기소개서 API 관련 리팩터링

<img width="1527" alt="image" src="https://github.com/depromeet/13th-4team-backend/assets/83271772/46278076-3701-4161-9903-4b94c98f0d5f">

## 📭 이슈 번호

---

#100 

<!-- 이슈 번호를 남겨주세요 -->

## 🧐 의견 구하기

---

<!-- 구하고 싶은 의견이 있다면 작성해주세요 -->

## 🙏 P.S

---

<!-- 추가적으로 남기고 싶은 말을 적어주세요 -->
