### PR TITLE
[Feature] 온보딩 업데이트 API 추가

### DIFF
--- a/src/apps/server/common/decorators/validation/isTrue.decorator.ts
+++ b/src/apps/server/common/decorators/validation/isTrue.decorator.ts
@@ -1,0 +1,27 @@
+import { ValidationArguments, ValidationOptions, registerDecorator } from 'class-validator';
+
+export function IsTrue(validationOptions?: ValidationOptions) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      name: 'isTrue',
+      target: object.constructor,
+      propertyName: propertyName,
+      constraints: [],
+      options: validationOptions,
+      validator: {
+        validate(value: any) {
+          if (typeof value !== 'boolean') {
+            return false;
+          }
+          if (value === false) {
+            return false;
+          }
+          return true;
+        },
+        defaultMessage(args: ValidationArguments) {
+          return `${args.property} must be true`;
+        },
+      },
+    });
+  };
+}

--- a/src/apps/server/onboarding/docs/patch-onboarding.doc.ts
+++ b/src/apps/server/onboarding/docs/patch-onboarding.doc.ts
@@ -1,0 +1,32 @@
+export const PatchOnboardingResponseDescriptionMd = `
+### ✅ 온보딩 여부 업데이트에 성공했습니다.
+각 화면 별로 온보딩이 완료됐을 때, 온보딩 여부를 업데이트합니다.
+응답으로 업데이트된 온보딩 데이터를 반환합니다.
+`;
+
+export const PatchOnboardingSummaryMd = `
+온보딩 여부 업데이트 API
+`;
+
+export const PatchOnboardingDescriptionMd = `
+# 온보딩 여부 업데이트 API
+
+## Description
+온보딩 여부를 업데이트합니다. 유저가 툴팁을 최초 확인하거나, 온보딩 페이지를 경험했을 때 업데이트합니다.
+온보딩/툴팁이 사용되는 위치는 아래와 같습니다.
+
+## Picture
+<img width="617" alt="image" src="https://github.com/depromeet/13th-4team-backend/assets/83271772/c3c28f00-08c4-4e28-a414-8663094bb6d2">
+
+<img width="593" alt="image" src="https://github.com/depromeet/13th-4team-backend/assets/83271772/2ae77be5-c540-432b-9b02-48fd7d4092b9">
+
+<img width="477" alt="image" src="https://github.com/depromeet/13th-4team-backend/assets/83271772/2186f084-d2a8-41a8-a1b7-05e9f8603ce6">
+
+<img width="391" alt="image" src="https://github.com/depromeet/13th-4team-backend/assets/83271772/ee530ab4-3a46-42b1-8f3f-55b5c04d670d">
+
+## Figma
+⛳️ [경험 분해 온보딩 팝업](https://www.figma.com/file/0ZJ1ulwtU8k0KQuroxU9Wc/%EC%9D%B8%EC%82%AC%EC%9D%B4%ED%8A%B8%EC%95%84%EC%9B%83?type=design&node-id=1833-11874&t=dUehEoPlyiDTcQPi-4)\n
+⛳️ [경험 분해 스텝퍼](https://www.figma.com/file/0ZJ1ulwtU8k0KQuroxU9Wc/%EC%9D%B8%EC%82%AC%EC%9D%B4%ED%8A%B8%EC%95%84%EC%9B%83?type=design&node-id=695-5705&t=dUehEoPlyiDTcQPi-4)\n
+⛳️ [자기소개서 작성 툴팁](https://www.figma.com/file/0ZJ1ulwtU8k0KQuroxU9Wc/%EC%9D%B8%EC%82%AC%EC%9D%B4%ED%8A%B8%EC%95%84%EC%9B%83?type=design&node-id=1221-8169&t=dUehEoPlyiDTcQPi-4)\n
+⛳️ [모아보기 정렬 툴팁](https://www.figma.com/file/0ZJ1ulwtU8k0KQuroxU9Wc/%EC%9D%B8%EC%82%AC%EC%9D%B4%ED%8A%B8%EC%95%84%EC%9B%83?type=design&node-id=1403-10706&t=dUehEoPlyiDTcQPi-4)
+`;

--- a/src/apps/server/onboarding/dtos/patch-onboarding.dto.ts
+++ b/src/apps/server/onboarding/dtos/patch-onboarding.dto.ts
@@ -1,0 +1,113 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Onboarding } from '@prisma/client';
+import { Exclude, Expose } from 'class-transformer';
+import { IsBoolean, IsNotEmpty, IsOptional } from 'class-validator';
+
+export class PatchOnboardingRequestBodyDto {
+  @ApiPropertyOptional({
+    description: '경험분해 온보딩 경험 여부',
+    example: true,
+    type: Boolean,
+  })
+  @IsBoolean()
+  @IsNotEmpty()
+  @IsOptional()
+  experience?: boolean;
+
+  // 곧 삭제될 툴팁
+  @ApiPropertyOptional({
+    description: '경험분해 스텝퍼에 사용되는 툴팁 경험 여부',
+    example: true,
+    type: Boolean,
+  })
+  @IsBoolean()
+  @IsNotEmpty()
+  @IsOptional()
+  experienceStepper?: boolean;
+
+  @ApiPropertyOptional({
+    description: '자기소개서 툴팁 경험 여부',
+    example: true,
+    type: Boolean,
+  })
+  @IsBoolean()
+  @IsNotEmpty()
+  @IsOptional()
+  resume?: boolean;
+
+  @ApiPropertyOptional({
+    description: '모아보기 정렬 툴팁 경험 여부',
+    example: true,
+    type: Boolean,
+  })
+  @IsBoolean()
+  @IsNotEmpty()
+  @IsOptional()
+  collection?: boolean;
+}
+
+export class PatchOnboardingResponseDto {
+  @Exclude() private readonly _experience?: boolean | undefined;
+  @Exclude() private readonly _experienceStepper?: boolean | undefined;
+  @Exclude() private readonly _resume?: boolean | undefined;
+  @Exclude() private readonly _collection?: boolean | undefined;
+
+  constructor(onboarding: Onboarding) {
+    this._experience = onboarding.experience;
+    this._experienceStepper = onboarding.experienceStepper;
+    this._resume = onboarding.resume;
+    this._collection = onboarding.collection;
+  }
+
+  @Expose()
+  @ApiPropertyOptional({
+    description: '경험분해 온보딩 경험 여부',
+    example: true,
+    type: Boolean,
+  })
+  @IsBoolean()
+  @IsNotEmpty()
+  @IsOptional()
+  get experience(): boolean {
+    return this._experience;
+  }
+
+  @Expose()
+  @ApiPropertyOptional({
+    description: '경험분해 스텝퍼에 사용되는 툴팁 경험 여부',
+    example: true,
+    type: Boolean,
+  })
+  @IsBoolean()
+  @IsNotEmpty()
+  @IsOptional()
+  get experienceStepper(): boolean {
+    return this._experienceStepper;
+  }
+
+  @Expose()
+  @ApiPropertyOptional({
+    description: '자기소개서 툴팁 경험 여부',
+    example: true,
+    type: Boolean,
+  })
+  @IsBoolean()
+  @IsNotEmpty()
+  @IsOptional()
+  get resume(): boolean {
+    return this._resume;
+  }
+
+  @Expose()
+  @ApiPropertyOptional({
+    description: '모아보기 정렬 툴팁 경험 여부',
+    example: true,
+    type: Boolean,
+  })
+  @IsBoolean()
+  @IsNotEmpty()
+  @IsOptional()
+  get collection(): boolean {
+    return this._collection;
+  }
+}

--- a/src/apps/server/onboarding/dtos/patch-onboarding.dto.ts
+++ b/src/apps/server/onboarding/dtos/patch-onboarding.dto.ts
@@ -2,6 +2,7 @@ import { ApiPropertyOptional } from '@nestjs/swagger';
 import { Onboarding } from '@prisma/client';
 import { Exclude, Expose } from 'class-transformer';
 import { IsBoolean, IsNotEmpty, IsOptional } from 'class-validator';
+import { IsTrue } from '🔥apps/server/common/decorators/validation/isTrue.decorator';
 
 export class PatchOnboardingRequestBodyDto {
   @ApiPropertyOptional({
@@ -9,7 +10,7 @@ export class PatchOnboardingRequestBodyDto {
     example: true,
     type: Boolean,
   })
-  @IsBoolean()
+  @IsTrue()
   @IsNotEmpty()
   @IsOptional()
   experience?: boolean;
@@ -20,7 +21,7 @@ export class PatchOnboardingRequestBodyDto {
     example: true,
     type: Boolean,
   })
-  @IsBoolean()
+  @IsTrue()
   @IsNotEmpty()
   @IsOptional()
   experienceStepper?: boolean;
@@ -30,7 +31,7 @@ export class PatchOnboardingRequestBodyDto {
     example: true,
     type: Boolean,
   })
-  @IsBoolean()
+  @IsTrue()
   @IsNotEmpty()
   @IsOptional()
   resume?: boolean;
@@ -40,7 +41,7 @@ export class PatchOnboardingRequestBodyDto {
     example: true,
     type: Boolean,
   })
-  @IsBoolean()
+  @IsTrue()
   @IsNotEmpty()
   @IsOptional()
   collection?: boolean;

--- a/src/apps/server/onboarding/onboarding.controller.ts
+++ b/src/apps/server/onboarding/onboarding.controller.ts
@@ -38,4 +38,23 @@ export class OnboardingsController {
 
     return ResponseEntity.OK_WITH_DATA(onboarding);
   }
+
+  @Route({
+    request: {
+      path: '',
+      method: Method.PATCH,
+    },
+    response: {
+      code: HttpStatus.OK,
+      type: PatchOnboardingResponseDto,
+    },
+  })
+  async updateOnboarding(
+    @User() user: UserJwtToken,
+    @Body() patchOnboardingRequestBodyDto: PatchOnboardingRequestBodyDto,
+  ): Promise<ResponseEntity<PatchOnboardingResponseDto>> {
+    const updatedOnboarding = await this.onboardingsService.updateOnboarding(user.userId, patchOnboardingRequestBodyDto);
+
+    return ResponseEntity.OK_WITH_DATA(updatedOnboarding);
+  }
 }

--- a/src/apps/server/onboarding/onboarding.controller.ts
+++ b/src/apps/server/onboarding/onboarding.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, HttpStatus, UseGuards } from '@nestjs/common';
+import { Body, Controller, HttpStatus, UseGuards } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { Method } from '📚libs/enums/method.enum';
 import { ResponseEntity } from '📚libs/utils/respone.entity';
@@ -11,7 +11,13 @@ import {
   GetOnboardingDescriptionMd,
   GetOnBoardingResponseDescription,
 } from '🔥apps/server/onboarding/docs/get-onboarding.doc';
+import {
+  PatchOnboardingDescriptionMd,
+  PatchOnboardingResponseDescriptionMd,
+  PatchOnboardingSummaryMd,
+} from '🔥apps/server/onboarding/docs/patch-onboarding.doc';
 import { GetAllOnboardingsResponseDto } from '🔥apps/server/onboarding/dtos/get-onboarding.dto';
+import { PatchOnboardingRequestBodyDto, PatchOnboardingResponseDto } from '🔥apps/server/onboarding/dtos/patch-onboarding.dto';
 import { OnboardingsService } from '🔥apps/server/onboarding/onboarding.service';
 
 @ApiTags('🏂 온보딩 API')
@@ -47,7 +53,10 @@ export class OnboardingsController {
     response: {
       code: HttpStatus.OK,
       type: PatchOnboardingResponseDto,
+      description: PatchOnboardingResponseDescriptionMd,
     },
+    summary: PatchOnboardingSummaryMd,
+    description: PatchOnboardingDescriptionMd,
   })
   async updateOnboarding(
     @User() user: UserJwtToken,

--- a/src/apps/server/onboarding/onboarding.service.ts
+++ b/src/apps/server/onboarding/onboarding.service.ts
@@ -1,6 +1,8 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { Onboarding } from '@prisma/client';
 import { OnboardingRepository } from '📚libs/modules/database/repositories/onboarding.repository';
 import { GetAllOnboardingsResponseDto } from '🔥apps/server/onboarding/dtos/get-onboarding.dto';
+import { PatchOnboardingResponseDto } from '🔥apps/server/onboarding/dtos/patch-onboarding.dto';
 
 @Injectable()
 export class OnboardingsService {
@@ -13,5 +15,19 @@ export class OnboardingsService {
 
     const onboardingResponseDto = new GetAllOnboardingsResponseDto(onboarding);
     return onboardingResponseDto;
+  }
+
+  async updateOnboarding(userId: number, onboardings: Omit<Partial<Onboarding>, 'userId'>): Promise<PatchOnboardingResponseDto> {
+    if (!Object.keys(onboardings).length) {
+      throw new BadRequestException('Please include onboarding at least 1.');
+    }
+
+    const updatedOnboarding = await this.onboardingRepository.update({
+      where: { userId },
+      data: onboardings,
+    });
+
+    const updateOnboardingResponseDto = new PatchOnboardingResponseDto(updatedOnboarding);
+    return updateOnboardingResponseDto;
   }
 }

--- a/src/apps/server/resumes/controllers/resumes.controller.ts
+++ b/src/apps/server/resumes/controllers/resumes.controller.ts
@@ -9,7 +9,6 @@ import { Route } from '🔥apps/server/common/decorators/router/route.decorator'
 import { JwtAuthGuard } from '🔥apps/server/common/guards/jwt-auth.guard';
 import {
   GetAllResumeRequestQueryDto,
-  GetAllResumeResponseDto,
   GetOneResumeRequestParamDto,
   GetOneResumeResponseDto,
 } from '🔥apps/server/resumes/dtos/get-resume.dto';
@@ -31,7 +30,7 @@ export class ResumesController {
     },
     response: {
       code: HttpStatus.OK,
-      type: GetAllResumeResponseDto,
+      type: GetOneResumeResponseDto,
       isArray: true,
       description:
         '### ✅ 자기소개서 전체 조회에 성공했습니다.\n유저가 작성한 모든 자기소개서를 반환하며, 각각의 자기소개서는 문항을 포함하고 문항의 답안은 Optional로 선택하여 가져올 수 있습니다.   \n자기소개서가 출력되는 기준은 모두 생성일자로부터 내림차순입니다. 자기소개서에 속한 자기소개서 문항도 마찬가지입니다.',
@@ -47,7 +46,7 @@ export class ResumesController {
   async getAllResumes(
     @User() user: UserJwtToken,
     @Query() getAllResumeRequestQueryDto: GetAllResumeRequestQueryDto,
-  ): Promise<ResponseEntity<GetAllResumeResponseDto>> {
+  ): Promise<ResponseEntity<GetOneResumeResponseDto[]>> {
     const resumes = await this.resumesService.getAllResumes(user.userId, getAllResumeRequestQueryDto);
 
     return ResponseEntity.OK_WITH_DATA(resumes);

--- a/src/apps/server/resumes/dtos/get-resume.dto.ts
+++ b/src/apps/server/resumes/dtos/get-resume.dto.ts
@@ -154,6 +154,7 @@ export class GetOneResumeResponseDto {
   @ApiProperty({
     description: '자기소개서 문항',
     type: QuestionResponse,
+    isArray: true,
   })
   @IsArray()
   @IsObject({ each: true })
@@ -163,5 +164,3 @@ export class GetOneResumeResponseDto {
     return this._question;
   }
 }
-
-export class GetAllResumeResponseDto extends Array<GetOneResumeResponseDto> {}

--- a/src/apps/server/resumes/services/resumes.service.ts
+++ b/src/apps/server/resumes/services/resumes.service.ts
@@ -2,7 +2,7 @@ import { ApiService } from '📚libs/modules/api/api.service';
 import { SpellCheckResult } from '📚libs/modules/api/api.type';
 import { ResumeRepository } from '📚libs/modules/database/repositories/resume.repository';
 import { Injectable, NotFoundException } from '@nestjs/common';
-import { GetAllResumeRequestQueryDto, GetAllResumeResponseDto, GetOneResumeResponseDto } from '🔥apps/server/resumes/dtos/get-resume.dto';
+import { GetAllResumeRequestQueryDto, GetOneResumeResponseDto } from '🔥apps/server/resumes/dtos/get-resume.dto';
 import { PatchResumeRequestDto } from '🔥apps/server/resumes/dtos/patch-resume.dto';
 import { PostResumeResponseDto } from '🔥apps/server/resumes/dtos/post-resume.dto';
 import { PostSpellCheckRequestBodyDto } from '🔥apps/server/resumes/dtos/post-spell-check-request.body.dto';
@@ -25,7 +25,7 @@ export class ResumesService {
    *
    * @returns 유저가 작성한 자기소개서를 문항과 함께 가져옵니다.
    */
-  public async getAllResumes(userId: number, query?: GetAllResumeRequestQueryDto): Promise<GetAllResumeResponseDto> {
+  public async getAllResumes(userId: number, query?: GetAllResumeRequestQueryDto): Promise<GetOneResumeResponseDto[]> {
     const { answer } = query;
 
     // 자기소개서와 문항을 함께 가져옵니다.

--- a/src/libs/modules/database/schema.prisma
+++ b/src/libs/modules/database/schema.prisma
@@ -93,6 +93,8 @@ model Onboarding {
   collection Boolean @default(false) // 모아보기 온보딩 여부
 
   User User @relation(references: [id], fields: [userId])
+
+  @@map("onboarding")
 }
 
 // ****************************


### PR DESCRIPTION
## ⛳️ 기능 구현 배경

---

<!-- 기능 구현 배경에 대해 작성해주세요 -->

온보딩 여부를 업데이트 하는 API 가 필요합니다. 온보딩이 모두 종료되고 업데이트 해야 다음 번애 동일한 온보딩/툴팁을 뱉지 않기 때문입니다.

## 😤 기능 구현 내용(Optional)

---

<!-- 기능 구현 내용에 대해 적어주세요 -->

```ts
  async updateOnboarding(userId: number, onboardings: Omit<Partial<Onboarding>, 'userId'>): Promise<PatchOnboardingResponseDto> {
    if (!Object.keys(onboardings).length) {
      throw new BadRequestException('Please include onboarding at least 1.');
    }

    const updatedOnboarding = await this.onboardingRepository.update({
      where: { userId },
      data: onboardings,
    });

    const updateOnboardingResponseDto = new PatchOnboardingResponseDto(updatedOnboarding);
    return updateOnboardingResponseDto;
  }
```
값이 하나라도 없으면 예외를 일으킵니다. 온보딩 된 것을 파악하여 업데이트합니다.

## 📭 이슈 번호

---

<!-- 이슈 번호를 남겨주세요 -->

#112 

## 🧐 의견 구하기

---

<!-- 구하고 싶은 의견이 있다면 작성해주세요 -->

request body에서 experience를 false로 둬도 업데이트가 발생하는 게 너무 아쉽습니다.
그래서 `@ValidateIf()` 데코레이터를 사용하려고 하는데요,

```ts
@ValidateIf((o) => o.experience)
get experience(): boolean {
  return this._experience;
}
```

이렇게 하고 요청 바디에 experience를 false로 둬도 api는 정상적으로 처리 돼서 experience 온보딩이 다시 false로 바뀌네요 ㅠㅠㅠㅠ
어떻게 하면 request dto 부분에서 각 요청의 속성이 ValidateIf에 있는 데코레이터 내부 함수에 적용이 되려나요...

<img width="457" alt="image" src="https://github.com/depromeet/13th-4team-backend/assets/83271772/33fd98ac-520b-4622-a726-fcac7dbb6664">


## 🙏 P.S

---

<!-- 추가적으로 남기고 싶은 말을 적어주세요 -->
