### PR TITLE
[Feature] 경험 카드와 자기소개서 count API

### DIFF
--- a/src/apps/server/app.module.ts
+++ b/src/apps/server/app.module.ts
@@ -17,6 +17,7 @@ import { TestModule } from './test/test.module';
 import { ExperienceModule } from '🔥apps/server/experiences/experience.module';
 import { UserModule } from '🔥apps/server/users/user.module';
 import { OnboardingsModule } from '🔥apps/server/onboarding/onboarding.module';
+import { CollectionsModule } from '🔥apps/server/collections/collection.module';
 
 @Module({
   controllers: [AppController],
@@ -38,6 +39,7 @@ import { OnboardingsModule } from '🔥apps/server/onboarding/onboarding.module'
     TestModule,
     UserModule,
     OnboardingsModule,
+    CollectionsModule,
   ],
   providers: [
     {

--- a/src/apps/server/collections/collection.controller.ts
+++ b/src/apps/server/collections/collection.controller.ts
@@ -4,6 +4,11 @@ import { Method } from '📚libs/enums/method.enum';
 import { ResponseEntity } from '📚libs/utils/respone.entity';
 import { UserJwtToken } from '🔥apps/server/auth/types/jwt-tokwn.type';
 import { CollectionsService } from '🔥apps/server/collections/collection.service';
+import {
+  GetCountOfExperienceAndResumeDescriptionMd,
+  GetCountOfExperienceAndResumeResponseDescriptionMd,
+  GetCountOfExperienceAndResumeSummaryMd,
+} from '🔥apps/server/collections/docs/get-count-of-experience-and-resume.doc';
 import { GetCountOfExperienceAndResumeResponseDto } from '🔥apps/server/collections/dtos/get-count-of-experience-and-resume.dto';
 import { User } from '🔥apps/server/common/decorators/request/user.decorator';
 import { Route } from '🔥apps/server/common/decorators/router/route.decorator';
@@ -22,7 +27,10 @@ export class CollectionsController {
     },
     response: {
       code: HttpStatus.OK,
+      description: GetCountOfExperienceAndResumeResponseDescriptionMd,
     },
+    summary: GetCountOfExperienceAndResumeSummaryMd,
+    description: GetCountOfExperienceAndResumeDescriptionMd,
   })
   async getCountOfExperienceAndResume(@User() user: UserJwtToken): Promise<ResponseEntity<GetCountOfExperienceAndResumeResponseDto>> {
     const countOfExperienceAndResume = await this.collectionsService.getCountOfExperienceAndResume(user.userId);

--- a/src/apps/server/collections/collection.controller.ts
+++ b/src/apps/server/collections/collection.controller.ts
@@ -1,6 +1,12 @@
-import { Controller, UseGuards } from '@nestjs/common';
+import { Controller, HttpStatus, UseGuards } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
+import { Method } from '📚libs/enums/method.enum';
+import { ResponseEntity } from '📚libs/utils/respone.entity';
+import { UserJwtToken } from '🔥apps/server/auth/types/jwt-tokwn.type';
 import { CollectionsService } from '🔥apps/server/collections/collection.service';
+import { GetCountOfExperienceAndResumeResponseDto } from '🔥apps/server/collections/dtos/get-count-of-experience-and-resume.dto';
+import { User } from '🔥apps/server/common/decorators/request/user.decorator';
+import { Route } from '🔥apps/server/common/decorators/router/route.decorator';
 import { JwtAuthGuard } from '🔥apps/server/common/guards/jwt-auth.guard';
 
 @ApiTags('🔍 모아보기 관련 API')
@@ -8,4 +14,19 @@ import { JwtAuthGuard } from '🔥apps/server/common/guards/jwt-auth.guard';
 @Controller('collections')
 export class CollectionsController {
   constructor(private readonly collectionsService: CollectionsService) {}
+
+  @Route({
+    request: {
+      path: 'count',
+      method: Method.GET,
+    },
+    response: {
+      code: HttpStatus.OK,
+    },
+  })
+  async getCountOfExperienceAndResume(@User() user: UserJwtToken): Promise<ResponseEntity<GetCountOfExperienceAndResumeResponseDto>> {
+    const countOfExperienceAndResume = await this.collectionsService.getCountOfExperienceAndResume(user.userId);
+
+    return ResponseEntity.OK_WITH_DATA(countOfExperienceAndResume);
+  }
 }

--- a/src/apps/server/collections/collection.controller.ts
+++ b/src/apps/server/collections/collection.controller.ts
@@ -1,0 +1,11 @@
+import { Controller, UseGuards } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { CollectionsService } from '🔥apps/server/collections/collection.service';
+import { JwtAuthGuard } from '🔥apps/server/common/guards/jwt-auth.guard';
+
+@ApiTags('🔍 모아보기 관련 API')
+@UseGuards(JwtAuthGuard)
+@Controller('collections')
+export class CollectionsController {
+  constructor(private readonly collectionsService: CollectionsService) {}
+}

--- a/src/apps/server/collections/collection.module.ts
+++ b/src/apps/server/collections/collection.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { ExperienceRepository } from '📚libs/modules/database/repositories/experience.repository';
+import { ResumeRepository } from '📚libs/modules/database/repositories/resume.repository';
+import { CollectionsController } from '🔥apps/server/collections/collection.controller';
+import { CollectionsService } from '🔥apps/server/collections/collection.service';
+
+@Module({
+  controllers: [CollectionsController],
+  providers: [CollectionsService, ExperienceRepository, ResumeRepository],
+})
+export class CollectionsModule {}

--- a/src/apps/server/collections/collection.service.ts
+++ b/src/apps/server/collections/collection.service.ts
@@ -1,8 +1,21 @@
 import { Injectable } from '@nestjs/common';
 import { ExperienceRepository } from '📚libs/modules/database/repositories/experience.repository';
 import { ResumeRepository } from '📚libs/modules/database/repositories/resume.repository';
+import { GetCountOfExperienceAndResumeResponseDto } from '🔥apps/server/collections/dtos/get-count-of-experience-and-resume.dto';
 
 @Injectable()
 export class CollectionsService {
   constructor(private readonly experienceRepository: ExperienceRepository, private readonly resumeRepository: ResumeRepository) {}
+
+  async getCountOfExperienceAndResume(userId: number): Promise<GetCountOfExperienceAndResumeResponseDto> {
+    const countOfExperience = await this.experienceRepository.countExperience(userId);
+
+    const countOfResume = await this.resumeRepository.count({
+      where: { userId },
+    });
+
+    const getCountOfExperienceAndResumeResponseDto = new GetCountOfExperienceAndResumeResponseDto(countOfExperience, countOfResume);
+
+    return getCountOfExperienceAndResumeResponseDto;
+  }
 }

--- a/src/apps/server/collections/collection.service.ts
+++ b/src/apps/server/collections/collection.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@nestjs/common';
+import { ExperienceRepository } from '📚libs/modules/database/repositories/experience.repository';
+import { ResumeRepository } from '📚libs/modules/database/repositories/resume.repository';
+
+@Injectable()
+export class CollectionsService {
+  constructor(private readonly experienceRepository: ExperienceRepository, private readonly resumeRepository: ResumeRepository) {}
+}

--- a/src/apps/server/collections/docs/get-count-of-experience-and-resume.doc.ts
+++ b/src/apps/server/collections/docs/get-count-of-experience-and-resume.doc.ts
@@ -1,0 +1,24 @@
+export const GetCountOfExperienceAndResumeResponseDescriptionMd = `
+### ✅ 경험 카드 개수 및 자기소개서 개수 조회에 성공했습니다.
+모아보기 최상단에 사용되는 각각의 개수 값입니다.
+`;
+
+export const GetCountOfExperienceAndResumeSummaryMd = `
+경험 카드 개수 및 자기소개서 개수 조회 API
+`;
+
+export const GetCountOfExperienceAndResumeDescriptionMd = `
+# 경험 카드 개수 및 자기소개서 개수 조회 API
+
+## Description
+
+경험 카드 개수와 자기소개서 개수를 조회합니다. 모아보기에서 가장 상단에 경험 카드 +99, 자기소개서 +99를 데이터를 가져와 매핑해야 합니다.
+
+## Picture
+
+<img width="433" alt="image" src="https://github.com/depromeet/13th-4team-backend/assets/83271772/75ac965a-057a-4084-8151-4e0c8eaa3495">
+
+## Figma
+
+⛳️ [모아보기 - 경험카드탭](https://www.figma.com/file/0ZJ1ulwtU8k0KQuroxU9Wc/%EC%9D%B8%EC%82%AC%EC%9D%B4%ED%8A%B8%EC%95%84%EC%9B%83?type=design&node-id=1403-10706&t=BGdyU14QTHF3scSm-4)
+`;

--- a/src/apps/server/collections/dtos/get-count-of-experience-and-resume.dto.ts
+++ b/src/apps/server/collections/dtos/get-count-of-experience-and-resume.dto.ts
@@ -1,0 +1,37 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Exclude, Expose } from 'class-transformer';
+import { IsInt, Min } from 'class-validator';
+
+export class GetCountOfExperienceAndResumeResponseDto {
+  @Exclude() private readonly _experience: number;
+  @Exclude() private readonly _resume: number;
+
+  constructor(countOfExperience: number, countOfResume: number) {
+    this._experience = countOfExperience;
+    this._resume = countOfResume;
+  }
+
+  @Expose()
+  @ApiProperty({
+    description: '생성된 경험 카드 개수입니다.',
+    example: 1234,
+    type: Number,
+  })
+  @IsInt()
+  @Min(0)
+  get experience(): number {
+    return this._experience;
+  }
+
+  @Expose()
+  @ApiProperty({
+    description: '생성된 자기소개서 개수입니다.',
+    example: 1234,
+    type: Number,
+  })
+  @IsInt()
+  @Min(0)
+  get resume(): number {
+    return this._resume;
+  }
+}

--- a/src/libs/modules/database/repositories/experience.repository.ts
+++ b/src/libs/modules/database/repositories/experience.repository.ts
@@ -35,7 +35,7 @@ export class ExperienceRepository implements ExperienceRepositoryInterface {
     });
   }
 
-  public async countExperience(userId: number) {
+  public async countExperience(userId: number): Promise<number> {
     return await this.prisma.experience.count({
       where: { userId },
     });

--- a/src/libs/modules/database/repositories/experience.repository.ts
+++ b/src/libs/modules/database/repositories/experience.repository.ts
@@ -34,4 +34,10 @@ export class ExperienceRepository implements ExperienceRepositoryInterface {
       where: { userId, experienceStatus: ExperienceStatus.INPROGRESS },
     });
   }
+
+  public async countExperience(userId: number) {
+    return await this.prisma.experience.count({
+      where: { userId },
+    });
+  }
 }


### PR DESCRIPTION
## ⛳️ 기능 구현 배경

---

<!-- 기능 구현 배경에 대해 작성해주세요 -->

모아보기 상단에 있는 경험 카드 개수와 자기소개서의 개수를 확인합니다.

## 😤 기능 구현 내용(Optional)

---

<!-- 기능 구현 내용에 대해 적어주세요 -->

경험 카드와 자기소개서 개수를 가져와서 반환합니다.

```ts
  async getCountOfExperienceAndResume(userId: number): Promise<GetCountOfExperienceAndResumeResponseDto> {
    const countOfExperience = await this.experienceRepository.countExperience(userId);

    const countOfResume = await this.resumeRepository.count({
      where: { userId },
    });

    const getCountOfExperienceAndResumeResponseDto = new GetCountOfExperienceAndResumeResponseDto(countOfExperience, countOfResume);

    return getCountOfExperienceAndResumeResponseDto;
  }
```

두 번의 count 쿼리가 생기고 response dto를 만들어 반환합니다.

## 📭 이슈 번호

---

<!-- 이슈 번호를 남겨주세요 -->

#121 

## 🧐 의견 구하기

---

<!-- 구하고 싶은 의견이 있다면 작성해주세요 -->

현재 모아보기에서 필요할 API는

1. 경험카드 자기소개서 count API
2. 경험카드 역량 키워드 조회 및 count API
3. 자기소개서 제목 조회API
4. 경험 카드 역량 키워드 별(혹은 전체 카드) 전체 조회 API,
5. 특정 자기소개서 1개 조회 API

일단 이 정도로 보이는데 모아보기쪽에서 API가 추가되거나 삭제할 만한 내용이 있을까요?

## 🙏 P.S

---

<!-- 추가적으로 남기고 싶은 말을 적어주세요 -->
