### PR TITLE
[Feature] 모아보기를 위한 경험 분해 조회 API 수정

### DIFF
--- a/src/apps/server/experiences/controllers/experience.controller.ts
+++ b/src/apps/server/experiences/controllers/experience.controller.ts
@@ -1,4 +1,4 @@
-import { Body, HttpStatus, UseGuards } from '@nestjs/common';
+import { Body, HttpStatus, Query, UseGuards } from '@nestjs/common';
 import { Route } from '../../common/decorators/router/route.decorator';
 import { RouteTable } from '../../common/decorators/router/route-table.decorator';
 import { UpsertExperienceReqDto } from '../dto/req/upsertExperience.dto';
@@ -16,6 +16,7 @@ import { ResponseEntity } from '📚libs/utils/respone.entity';
 import { GetExperienceNotFoundErrorResDto, GetExperienceResDto } from '../dto/res/getExperience.res.dto';
 import { Method } from '📚libs/enums/method.enum';
 import { getExperienceSuccMd, upsertExperienceSuccMd } from '🔥apps/server/experiences/markdown/experience.md';
+import { GetExperienceRequestQueryDto } from '🔥apps/server/experiences/dto/req/get-experience.dto';
 
 @ApiBearerAuth()
 @UseGuards(JwtAuthGuard)
@@ -70,8 +71,19 @@ export class ExperienceController {
     description: '⛔ 해당 경험 카드 ID를 확인해주세요 :)',
     type: GetExperienceNotFoundErrorResDto,
   })
-  public async getExperience(@User() user: UserJwtToken) {
-    const experience = await this.experienceService.getExperienceByUserId(user.userId);
+  public async getExperience(@User() user: UserJwtToken, @Query() getExperienceRequestQueryDto?: GetExperienceRequestQueryDto) {
+    let experience;
+
+    if (getExperienceRequestQueryDto.capabilityId) {
+      experience = await this.experienceService.getExperienceByCapability(getExperienceRequestQueryDto.capabilityId);
+    } else {
+      // TODO 추후 전체 모아보기를 위해 수정 필요
+      experience = await this.experienceService.getExperiencesByUserId(user.userId);
+    }
+
+    if (getExperienceRequestQueryDto.last) {
+      experience = experience[0];
+    }
 
     return ResponseEntity.OK_WITH_DATA(experience);
   }

--- a/src/apps/server/experiences/dto/req/get-experience.dto.ts
+++ b/src/apps/server/experiences/dto/req/get-experience.dto.ts
@@ -1,0 +1,26 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Transform, Type } from 'class-transformer';
+import { IsBoolean, IsInt, IsNotEmpty, IsOptional, IsPositive } from 'class-validator';
+
+export class GetExperienceRequestQueryDto {
+  @ApiPropertyOptional({
+    description: '역량 키워드 id',
+  })
+  @IsOptional()
+  @IsInt()
+  @IsPositive()
+  @IsNotEmpty()
+  @Type(() => Number)
+  capabilityId?: number;
+
+  @ApiPropertyOptional({
+    description: '가장 최근 경험분해 하나만 가져올지 여부입니다.',
+  })
+  @IsOptional()
+  @IsBoolean()
+  @IsNotEmpty()
+  @Transform((_) => {
+    return _.obj.last === 'true' ? true : false;
+  })
+  last?: boolean;
+}

--- a/src/apps/server/experiences/dto/res/getExperience.res.dto.ts
+++ b/src/apps/server/experiences/dto/res/getExperience.res.dto.ts
@@ -176,7 +176,7 @@ export class GetExperienceByCapabilityResponseDto {
   constructor(
     experience: Experience & {
       User: {
-        Capability: Capability[];
+        Capability: Omit<Capability, 'userId'>[];
       };
     },
   ) {

--- a/src/apps/server/experiences/dto/res/getExperience.res.dto.ts
+++ b/src/apps/server/experiences/dto/res/getExperience.res.dto.ts
@@ -82,6 +82,7 @@ export class GetExperienceResDto {
     this._startDate = experience.startDate;
     this._endDate = experience.endDate;
     this._experienceStatus = experience.experienceStatus;
+    this._situation = experience.situation;
     this._task = experience.task;
     this._action = experience.action;
     this._result = experience.result;

--- a/src/apps/server/experiences/services/experience.service.ts
+++ b/src/apps/server/experiences/services/experience.service.ts
@@ -1,20 +1,20 @@
 import { Inject, Injectable, NotFoundException, UnprocessableEntityException } from '@nestjs/common';
 import { UpsertExperienceReqDto } from '../dto/req/upsertExperience.dto';
 import { UserJwtToken } from '../../auth/types/jwt-tokwn.type';
-import { ExperienceRepositoryInterface } from '../interface/experience-repository.interface';
 import { UpsertExperienceResDto } from '../dto/res/upsertExperienceInfo.res.dto';
 import { getExperienceAttribute } from '../../common/consts/experience-attribute.const';
-import { GetExperienceResDto } from '../dto/res/getExperience.res.dto';
+import { GetExperienceByCapabilityResponseDto, GetExperienceResDto } from '../dto/res/getExperience.res.dto';
 import { Experience, ExperienceInfo, ExperienceStatus, Prisma } from '@prisma/client';
 import { PrismaService } from '📚libs/modules/database/prisma.service';
 import { ExperienceRepository } from '📚libs/modules/database/repositories/experience.repository';
+import { CapabilityRepository } from '📚libs/modules/database/repositories/capability.repository';
 
 @Injectable()
 export class ExperienceService {
   constructor(
-    @Inject(ExperienceRepository)
-    private readonly experienceRepository: ExperienceRepositoryInterface,
+    private readonly experienceRepository: ExperienceRepository,
     private readonly prisma: PrismaService,
+    private readonly capabilityRepository: CapabilityRepository,
   ) {}
 
   public async upsertExperience(body: UpsertExperienceReqDto, user: UserJwtToken): Promise<UpsertExperienceResDto> {
@@ -46,12 +46,35 @@ export class ExperienceService {
     }
   }
 
+  public async getExperienceByCapability(capabilityId: number): Promise<GetExperienceByCapabilityResponseDto[]> {
+    const experience = await this.experienceRepository.getExperienceByCapability(capabilityId);
+    if (!experience.length) {
+      throw new NotFoundException('Experience not found');
+    }
+
+    const getExperienceByCapabilityResponseDto = experience.map((experience) => new GetExperienceByCapabilityResponseDto(experience));
+
+    return getExperienceByCapabilityResponseDto;
+  }
+
   public async getExperienceByUserId(userId: number): Promise<GetExperienceResDto | string> {
     try {
       const experience = await this.experienceRepository.selectOneByUserId(userId, getExperienceAttribute);
       if (!experience) return 'INPROGRESS 상태의 경험카드가 없습니다';
 
       return new GetExperienceResDto(experience);
+    } catch (error) {
+      console.log('error', error);
+      if (error instanceof Prisma.PrismaClientKnownRequestError) throw new NotFoundException('INPROGRESS 상태의 경험카드가 없습니다.');
+    }
+  }
+
+  public async getExperiencesByUserId(userId: number): Promise<GetExperienceResDto[] | string> {
+    try {
+      const experience = await this.experienceRepository.findManyByUserId(userId, getExperienceAttribute);
+      if (!experience.length) return 'INPROGRESS 상태의 경험카드가 없습니다';
+
+      return experience.map((experience) => new GetExperienceResDto(experience));
     } catch (error) {
       console.log('error', error);
       if (error instanceof Prisma.PrismaClientKnownRequestError) throw new NotFoundException('INPROGRESS 상태의 경험카드가 없습니다.');

--- a/src/libs/modules/database/repositories/abstract.repository.ts
+++ b/src/libs/modules/database/repositories/abstract.repository.ts
@@ -65,7 +65,5 @@ export type DelegateArgs<T> = {
 };
 
 export type DelegateReturnTypes<T> = {
-  [Key in keyof T]: T[Key] extends (...args: any[]) => any
-    ? ReturnType<T[Key]>
-    : never;
+  [Key in keyof T]: T[Key] extends (...args: any[]) => any ? ReturnType<T[Key]> : never;
 };

--- a/src/libs/modules/database/repositories/experience.repository.ts
+++ b/src/libs/modules/database/repositories/experience.repository.ts
@@ -52,7 +52,7 @@ export class ExperienceRepository implements ExperienceRepositoryInterface {
     // TODO ai 역량 키워드가 적용되면 해당 키워드도 함께 쿼리로 가져와야 함.
     return await this.prisma.experience.findMany({
       where: { ExperienceCapability: { some: { capabilityId: { equals: capabilityId } } } },
-      include: { User: { select: { Capability: { where: { id: capabilityId } } } } },
+      include: { User: { select: { Capability: { where: { id: capabilityId }, select: { id: true, keyword: true } } } } },
       orderBy: { createdAt: 'desc' },
     });
   }

--- a/src/libs/modules/database/repositories/experience.repository.ts
+++ b/src/libs/modules/database/repositories/experience.repository.ts
@@ -28,6 +28,13 @@ export class ExperienceRepository implements ExperienceRepositoryInterface {
     });
   }
 
+  public async findManyByUserId(userId: number, select: ExperienceSelect) {
+    return await this.prisma.experience.findMany({
+      select,
+      orderBy: { createdAt: 'desc' },
+    });
+  }
+
   public async findOneByUserId(userId: number): Promise<Experience> {
     return await this.prisma.experience.findFirst({
       include: { ExperienceInfo: true },
@@ -38,6 +45,15 @@ export class ExperienceRepository implements ExperienceRepositoryInterface {
   public async countExperience(userId: number): Promise<number> {
     return await this.prisma.experience.count({
       where: { userId },
+    });
+  }
+
+  public async getExperienceByCapability(capabilityId: number) {
+    // TODO ai 역량 키워드가 적용되면 해당 키워드도 함께 쿼리로 가져와야 함.
+    return await this.prisma.experience.findMany({
+      where: { ExperienceCapability: { some: { capabilityId: { equals: capabilityId } } } },
+      include: { User: { select: { Capability: { where: { id: capabilityId } } } } },
+      orderBy: { createdAt: 'desc' },
     });
   }
 }

--- a/src/libs/modules/database/schema.prisma
+++ b/src/libs/modules/database/schema.prisma
@@ -15,7 +15,7 @@ datasource db {
 // ****************************
 
 model User {
-  id       Int    @id @default(autoincrement()) @map("user_id")
+  id       Int    @id @default(autoincrement())
   email    String @unique @db.VarChar(100)
   uid      String @unique @db.Text // 구글 uid
   socialId String @map("social_id") @db.Text


### PR DESCRIPTION
## ⛳️ 기능 구현 배경

---

<!-- 기능 구현 배경에 대해 작성해주세요 -->

모아보기에서 키워드별로 조회하는 API가 필요한데, 기존의 API가 그 역할을 하고 있어서 코드 로직을 수정했습니다.

## 😤 기능 구현 내용(Optional)

---

<!-- 기능 구현 내용에 대해 적어주세요 -->

### query string 추가

```ts
  public async getExperience(@User() user: UserJwtToken, @Query() getExperienceRequestQueryDto?: GetExperienceRequestQueryDto) {
    let experience;

    if (getExperienceRequestQueryDto.capabilityId) {
      experience = await this.experienceService.getExperienceByCapability(getExperienceRequestQueryDto.capabilityId);
    } else {
      // TODO 추후 전체 모아보기를 위해 수정 필요
      experience = await this.experienceService.getExperiencesByUserId(user.userId);
    }

    if (getExperienceRequestQueryDto.last) {
      experience = experience[0];
    }
```

전체 경험카드를 쿼리를 사용해서 역량 키워드에 맞는 경험 카드만 가져오거나 마지막 한 개만 가져옵니다.

### Prisma 쿼리 작성

```ts
  public async getExperienceByCapability(capabilityId: number) {
    // TODO ai 역량 키워드가 적용되면 해당 키워드도 함께 쿼리로 가져와야 함.
    return await this.prisma.experience.findMany({
      where: { ExperienceCapability: { some: { capabilityId: { equals: capabilityId } } } },
      include: { User: { select: { Capability: { where: { id: capabilityId } } } } },
      orderBy: { createdAt: 'desc' },
    });
  }
```

흠... 만족스러운 쿼리는 아니네요. 그냥 N:M으로 해야 할까요? 지금 junction 테이블 거쳐서 조회를 하는데, Prisma에서는 방법이 없네요. TypeOrm이었으면, InnerJoin이랑 select 하면서 가져왔을 텐데

## 📭 이슈 번호

---

<!-- 이슈 번호를 남겨주세요 -->

#128 

## 🧐 의견 구하기

---

<!-- 구하고 싶은 의견이 있다면 작성해주세요 -->

## 🙏 P.S

---

<!-- 추가적으로 남기고 싶은 말을 적어주세요 -->
